### PR TITLE
Fix Streamlit Cloud deploy and add deploy-check CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,29 @@ jobs:
 
       - name: Run tests
         run: pytest -v
+
+  # Mirrors how Streamlit Community Cloud builds the app (Debian trixie base,
+  # apt packages from packages.txt, pip install from requirements.txt) so a
+  # broken apt pin or requirement fails the PR instead of the deploy.
+  streamlit-deploy-check:
+    runs-on: ubuntu-latest
+    container: debian:trixie-slim
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install apt packages from packages.txt
+        run: |
+          apt-get update
+          xargs -a packages.txt apt-get install -y --no-install-recommends
+
+      - name: Install Python dependencies
+        run: |
+          apt-get install -y --no-install-recommends python3 python3-venv python3-pip
+          python3 -m venv /tmp/venv
+          /tmp/venv/bin/pip install -r requirements.txt
+
+      - name: Compile all sources
+        run: /tmp/venv/bin/python -m py_compile 1_💼_Portfolio_Pulse.py streamlit_app.py common/*.py pages/*.py scripts/*.py
+
+      - name: Import entrypoint dependencies
+        run: /tmp/venv/bin/python -c "import streamlit, pandas, numpy, plotly, duckdb, polars, yfinance, pypfopt, scipy"

--- a/packages.txt
+++ b/packages.txt
@@ -1,3 +1,2 @@
 build-essential
 pkg-config
-libwebkit2gtk-4.0-37


### PR DESCRIPTION
libwebkit2gtk-4.0-37 in packages.txt has unresolvable dependencies on Streamlit Community Cloud's Debian trixie base image, failing every deploy — and nothing in the app uses webkit, so drop it.

Add a CI job that mirrors the Streamlit Cloud build (Debian trixie container, apt install from packages.txt, pip install from pinned requirements, compile + import check) so broken apt pins or requirements fail the PR instead of the deploy.


Claude-Session: https://claude.ai/code/session_01Wz4SfNp9NYyGhLpFcYhd77