### PR TITLE
Add Smart Money Radar: thematic early-trend detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The app is organized by asset class:
 - **Fixed Income:** US Treasury yield curve, curve slope/inversion, and macro gauges (DXY, VIX).
 - **Commodities:** Futures performance, rolling volatility, and cross-commodity correlations.
 - **Digital Assets:** Crypto risk/return metrics (365-day annualization), drawdown timelines, ETH/BTC relative strength, and correlation vs equities and gold.
+- **Thematic & Flows:** Smart Money Radar — ranks ~16 thematic baskets (AI, crypto, nuclear, quantum, rare earths, GLP-1 …) by accumulation evidence rather than trailing return, with lifecycle staging, a rotation heatmap, 30-day change alerts, and SEC EDGAR insider (Form 4) and institutional (13F) filings.
 
 Highlights:
 
@@ -32,6 +33,24 @@ Highlights:
 - **Portfolio Optimization:** Optimize your portfolio using the efficient frontier for the maximum Sharpe ratio.
 - **Visualizations:** Generate interactive charts and plots for enhanced data presentation.
 - **Performance Metrics:** Track KPIs like expected annual return, annual volatility, and Sharpe ratio.
+
+### Smart Money Radar
+
+The radar combines two evidence layers, both free and key-less:
+
+1. **Price/volume accumulation signals** (Yahoo Finance) — Chaikin Money Flow, dollar-volume
+   thrust, relative-strength acceleration and breadth, composited so that money arriving now
+   outweighs returns already booked. These are a *proxy* for institutional flow, not flow data.
+2. **SEC EDGAR filings** — Form 4 open-market insider purchases (transaction code `P` only) and
+   13F institutional position changes. 13F holdings are filed up to 45 days after quarter end,
+   so they confirm a theme rather than front-run it.
+
+SEC's fair-access policy asks for a contact address in the request User-Agent. Set
+`SEC_CONTACT_EMAIL` to a mailbox you read; otherwise a placeholder is used.
+
+```sh
+export SEC_CONTACT_EMAIL="you@example.com"
+```
 
 ## Installation
 

--- a/common/data.py
+++ b/common/data.py
@@ -38,18 +38,15 @@ def _fetch_from_duckdb(tickers, start, end, db_path=MARKET_DATA_DB):
     return df.pivot(index="date", columns="symbol", values="close_price")
 
 
-def _fetch_from_yfinance(tickers, start, end, max_retries=3, retry_delay=5):
-    """Fetch close prices from Yahoo Finance with rate-limit retries."""
+def _yf_download_with_retry(tickers, start, end, max_retries=3, retry_delay=5, **kwargs):
+    """Call yf.download, retrying only on rate limits.
+
+    Returns None when the download could not be completed, so callers can
+    tell "no data" apart from an empty-but-valid frame.
+    """
     for attempt in range(max_retries):
         try:
-            df_yf = yf.download(
-                tickers, start=start, end=end,
-                auto_adjust=False, multi_level_index=False,
-            )["Close"]
-            if isinstance(df_yf, pd.Series):
-                df_yf = df_yf.to_frame(name=tickers[0] if isinstance(tickers, (list, tuple)) else tickers)
-            df_yf.index = pd.to_datetime(df_yf.index).date
-            return df_yf.dropna(axis=1, how="all")
+            return yf.download(tickers, start=start, end=end, auto_adjust=False, **kwargs)
         except Exception as e:
             if "rate limit" in str(e).lower() or "too many requests" in str(e).lower():
                 if attempt < max_retries - 1:
@@ -57,11 +54,80 @@ def _fetch_from_yfinance(tickers, start, end, max_retries=3, retry_delay=5):
                     time.sleep(retry_delay)
                 else:
                     st.error("Too many requests to Yahoo Finance. Please try again later.")
-                    return pd.DataFrame()
+                    return None
             else:
                 st.error(f"Error fetching data from yfinance: {e}")
-                return pd.DataFrame()
-    return pd.DataFrame()
+                return None
+    return None
+
+
+def _fetch_from_yfinance(tickers, start, end, max_retries=3, retry_delay=5):
+    """Fetch close prices from Yahoo Finance with rate-limit retries."""
+    raw = _yf_download_with_retry(
+        tickers, start, end, max_retries, retry_delay, multi_level_index=False,
+    )
+    if raw is None or "Close" not in raw:
+        return pd.DataFrame()
+    df_yf = raw["Close"]
+    if isinstance(df_yf, pd.Series):
+        df_yf = df_yf.to_frame(name=tickers[0] if isinstance(tickers, (list, tuple)) else tickers)
+    df_yf.index = pd.to_datetime(df_yf.index).date
+    return df_yf.dropna(axis=1, how="all")
+
+
+OHLCV_FIELDS = ("Close", "High", "Low", "Volume")
+
+
+def _fetch_ohlcv_from_yfinance(tickers, start, end, max_retries=3, retry_delay=5):
+    """Fetch Close/High/Low/Volume frames keyed by field name.
+
+    yfinance returns a (field, ticker) MultiIndex — two levels even for a
+    single ticker — so each field slices out as a ticker-columned frame.
+    """
+    raw = _yf_download_with_retry(tickers, start, end, max_retries, retry_delay)
+    if raw is None or raw.empty:
+        return {}
+
+    frames = {}
+    for field in OHLCV_FIELDS:
+        if raw.columns.nlevels > 1:
+            if field not in raw.columns.get_level_values(0):
+                continue
+            frame = raw[field]
+        elif field in raw.columns:
+            frame = raw[[field]]
+            frame.columns = [tickers[0] if isinstance(tickers, (list, tuple)) else tickers]
+        else:
+            continue
+        if isinstance(frame, pd.Series):
+            frame = frame.to_frame()
+        frame = frame.copy()
+        frame.index = pd.to_datetime(frame.index)
+        frames[field] = frame.dropna(axis=1, how="all")
+
+    if "Close" not in frames or frames["Close"].empty:
+        return {}
+    # Keep every field on the same surviving symbols so downstream signals
+    # never mix a price column with a missing volume column.
+    symbols = list(frames["Close"].columns)
+    return {
+        field: frame.reindex(columns=symbols)
+        for field, frame in frames.items()
+    }
+
+
+@st.cache_data(ttl=86400)
+def get_ohlcv_data(tickers, start, end):
+    """Close/High/Low/Volume frames for tickers, indexed by timestamp.
+
+    Used by the Smart Money Radar, which needs volume and intraday range for
+    money-flow signals rather than the close-only series get_price_data
+    returns. Yahoo Finance only — the local DuckDB store holds closes alone.
+    """
+    tickers = list(tickers)
+    if not tickers:
+        return {}
+    return _fetch_ohlcv_from_yfinance(tickers, start, end)
 
 
 @st.cache_data(ttl=86400)

--- a/common/navigation.py
+++ b/common/navigation.py
@@ -30,6 +30,9 @@ PAGE_SECTIONS = {
     "🪙 Digital Assets": [
         ("views/crypto.py", "Crypto Metrics", "🪙", "crypto"),
     ],
+    "🧭 Thematic & Flows": [
+        ("views/smart_money.py", "Smart Money Radar", "🧭", "smart-money"),
+    ],
 }
 
 DEFAULT_PAGE = "views/portfolio_pulse.py"

--- a/common/sec_edgar.py
+++ b/common/sec_edgar.py
@@ -1,0 +1,472 @@
+"""SEC EDGAR client for insider (Form 4) and institutional (13F) activity.
+
+EDGAR is free and needs no API key — only a declared User-Agent and a
+courteous request rate. That makes it the one genuinely "smart money" data
+source available to this app, alongside the price/volume proxies in
+``common.smart_money``.
+
+Two caveats the UI must keep visible:
+
+* 13F holdings are filed up to 45 days after quarter end, so they confirm a
+  theme rather than front-run it.
+* Only Form 4 transaction code ``P`` is an open-market purchase. Codes ``A``
+  (grant), ``M`` (option exercise) and ``F`` (tax withholding) are
+  compensation mechanics, not conviction, and are filtered out.
+
+Parsing helpers are pure functions so they can be unit tested against XML
+fixtures; only the network wrappers touch Streamlit's cache.
+"""
+
+import json
+import os
+import re
+import threading
+import time
+import xml.etree.ElementTree as ET
+from datetime import date, timedelta
+
+import pandas as pd
+import requests
+import streamlit as st
+
+# SEC's fair-access policy requires a User-Agent carrying a contact address,
+# and rejects strings containing a URL instead of an email. Deployers should
+# point SEC_CONTACT_EMAIL at a mailbox they actually read; the placeholder
+# below keeps the app working out of the box without publishing anyone's
+# personal address in source control.
+DEFAULT_CONTACT_EMAIL = "portfolio-pulse@example.com"
+
+
+def _user_agent():
+    """Identify this client to SEC, honouring a deployer-supplied contact."""
+    contact = os.environ.get("SEC_CONTACT_EMAIL", "").strip() or DEFAULT_CONTACT_EMAIL
+    return f"PortfolioPulse/1.0 ({contact})"
+
+
+# SEC asks for no more than 10 requests/second; stay comfortably under.
+MAX_REQUESTS_PER_SECOND = 8
+REQUEST_TIMEOUT = 20
+
+SUBMISSIONS_URL = "https://data.sec.gov/submissions/CIK{cik:010d}.json"
+ARCHIVES_URL = "https://www.sec.gov/Archives/edgar/data/{cik}/{accession}"
+COMPANY_TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
+
+# 13F "value" switched from thousands of dollars to whole dollars for periods
+# from 2023 onward (SEC release 34-95148).
+VALUE_IN_DOLLARS_FROM = date(2023, 1, 1)
+
+INSIDER_BUY_CODE = "P"
+
+# Verified against data.sec.gov/submissions — each entity name confirmed and
+# each is an active 13F-HR filer.
+CURATED_MANAGERS = {
+    1067983: "Berkshire Hathaway",
+    1350694: "Bridgewater Associates",
+    1037389: "Renaissance Technologies",
+    1423053: "Citadel Advisors",
+    1167483: "Tiger Global Management",
+    1135730: "Coatue Management",
+    1536411: "Duquesne Family Office",
+    1656456: "Appaloosa",
+    1061165: "Lone Pine Capital",
+    1103804: "Viking Global Investors",
+    1040273: "Third Point",
+    1603466: "Point72 Asset Management",
+    1273087: "Millennium Management",
+    1697748: "ARK Investment Management",
+    1029160: "Soros Fund Management",
+}
+
+# Corporate-form noise stripped before matching a 13F issuer name to a ticker.
+_NAME_NOISE = {
+    "INC", "INCORPORATED", "CORP", "CORPORATION", "CO", "COMPANY", "COS",
+    "LTD", "LIMITED", "PLC", "LP", "LLC", "LLP", "NV", "SA", "AG", "AB",
+    "HOLDINGS", "HOLDING", "HLDGS", "HLDG", "GROUP", "GRP", "THE", "TR",
+    "TRUST", "COM", "COMMON", "STK", "SHS", "ADR", "ADS", "SPONSORED",
+    "SPON", "NEW", "DEL", "CLASS", "CL", "SER", "ORD", "PAR", "REIT",
+}
+_CLASS_SUFFIX = re.compile(r"\b(CL|CLASS|SER|SERIES)\s+[A-Z]\b")
+
+_rate_lock = threading.Lock()
+_last_request = 0.0
+
+
+def _throttle():
+    """Space requests out so the client stays inside SEC's rate limit."""
+    global _last_request
+    with _rate_lock:
+        gap = time.monotonic() - _last_request
+        minimum = 1.0 / MAX_REQUESTS_PER_SECOND
+        if gap < minimum:
+            time.sleep(minimum - gap)
+        _last_request = time.monotonic()
+
+
+@st.cache_resource
+def _session():
+    """Requests session carrying the User-Agent SEC requires.
+
+    No explicit Accept-Encoding: requests advertises only codings it can
+    decode, and hardcoding "br" breaks without the optional brotli package.
+    """
+    session = requests.Session()
+    session.headers.update({"User-Agent": _user_agent()})
+    return session
+
+
+def _get(url, max_retries=3, backoff=1.5):
+    """Throttled GET returning the response body, or None on failure.
+
+    EDGAR throttles by IP and answers a burst with 403 rather than 429, so
+    both are retried with backoff. Any other status is a real miss (a filing
+    directory that does not exist) and returns immediately.
+    """
+    delay = backoff
+    for attempt in range(max_retries):
+        try:
+            _throttle()
+            response = _session().get(url, timeout=REQUEST_TIMEOUT)
+            if response.status_code == 200:
+                return response.content
+            if response.status_code not in (403, 429, 503):
+                return None
+        except requests.RequestException:
+            pass
+        if attempt < max_retries - 1:
+            time.sleep(delay)
+            delay *= 2
+    return None
+
+
+# --- Pure parsing helpers ------------------------------------------------
+
+def _local(tag):
+    """Element tag without its XML namespace."""
+    return tag.split("}")[-1]
+
+
+def _text(element, name):
+    """Text of the first descendant with this (namespace-agnostic) tag name.
+
+    Ownership forms wrap most transaction fields in a <value> child —
+    <transactionShares><value>100</value></transactionShares> — so unwrap
+    that level when it is present, otherwise read the element's own text.
+    """
+    for child in element.iter():
+        if _local(child.tag) != name:
+            continue
+        for grandchild in child:
+            if _local(grandchild.tag) == "value":
+                return (grandchild.text or "").strip()
+        return (child.text or "").strip()
+    return None
+
+
+def normalize_issuer_name(name):
+    """Reduce a company name to a comparable key.
+
+    13F info tables spell issuers differently from EDGAR's company index
+    ("NVIDIA CORPORATION" vs "NVIDIA Corp"), so both sides are stripped of
+    punctuation, share-class markers and corporate-form suffixes.
+    """
+    if not name:
+        return ""
+    text = re.sub(r"[^A-Z0-9 ]", " ", str(name).upper())
+    text = _CLASS_SUFFIX.sub(" ", text)
+    words = [w for w in text.split() if w and w not in _NAME_NOISE]
+    return " ".join(words)
+
+
+def parse_form4_xml(data):
+    """Extract non-derivative transactions from one Form 4 filing.
+
+    Returns one record per transaction with its code, size and price. The
+    caller decides which codes matter; nothing is filtered here.
+    """
+    if not data:
+        return []
+    try:
+        root = ET.fromstring(data)
+    except ET.ParseError:
+        return []
+
+    symbol = _text(root, "issuerTradingSymbol")
+    owner = _text(root, "rptOwnerName")
+    is_director = _text(root, "isDirector") in ("1", "true")
+    is_officer = _text(root, "isOfficer") in ("1", "true")
+    title = _text(root, "officerTitle")
+
+    records = []
+    for node in root.iter():
+        if _local(node.tag) != "nonDerivativeTransaction":
+            continue
+        code = _text(node, "transactionCode")
+        try:
+            shares = float(_text(node, "transactionShares") or "nan")
+            price = float(_text(node, "transactionPricePerShare") or "nan")
+        except ValueError:
+            continue
+        records.append({
+            "ticker": symbol,
+            "owner": owner,
+            "role": title or ("Director" if is_director else "Officer" if is_officer else ""),
+            "code": code,
+            "acquired": _text(node, "transactionAcquiredDisposedCode"),
+            "shares": shares,
+            "price": price,
+            "value": shares * price if pd.notna(shares) and pd.notna(price) else float("nan"),
+            "transaction_date": _text(node, "transactionDate"),
+        })
+    return records
+
+
+def parse_infotable_xml(data):
+    """Parse a 13F information table into a positions DataFrame."""
+    columns = ["issuer", "cusip", "value", "shares"]
+    if not data:
+        return pd.DataFrame(columns=columns)
+    try:
+        root = ET.fromstring(data)
+    except ET.ParseError:
+        return pd.DataFrame(columns=columns)
+
+    rows = []
+    for node in root.iter():
+        if _local(node.tag) != "infoTable":
+            continue
+        try:
+            value = float(_text(node, "value") or "nan")
+        except ValueError:
+            value = float("nan")
+        try:
+            shares = float(_text(node, "sshPrnamt") or "nan")
+        except ValueError:
+            shares = float("nan")
+        rows.append({
+            "issuer": _text(node, "nameOfIssuer"),
+            "cusip": (_text(node, "cusip") or "").upper(),
+            "value": value,
+            "shares": shares,
+        })
+    if not rows:
+        return pd.DataFrame(columns=columns)
+    # One manager can report the same issuer across several accounts.
+    return (
+        pd.DataFrame(rows)
+        .groupby(["issuer", "cusip"], as_index=False)[["value", "shares"]]
+        .sum()
+    )
+
+
+def normalize_position_values(positions, report_date):
+    """Put 13F values in whole dollars regardless of filing vintage."""
+    if positions.empty:
+        return positions
+    scaled = positions.copy()
+    if report_date and report_date < VALUE_IN_DOLLARS_FROM:
+        scaled["value"] = scaled["value"] * 1000
+    return scaled
+
+
+def build_issuer_ticker_map(titles_by_ticker):
+    """Normalized company name -> ticker, for the universe we care about."""
+    mapping = {}
+    for ticker, title in titles_by_ticker.items():
+        key = normalize_issuer_name(title)
+        if key:
+            mapping.setdefault(key, ticker)
+    return mapping
+
+
+def map_positions_to_tickers(positions, issuer_map):
+    """Attach a ticker to each 13F position where the issuer name resolves.
+
+    Unmatched rows keep a null ticker rather than being dropped, so the page
+    can show how much value went unmapped instead of quietly losing it.
+    """
+    if positions.empty:
+        return positions.assign(ticker=pd.Series(dtype=object))
+    resolved = positions.copy()
+    resolved["ticker"] = [
+        issuer_map.get(normalize_issuer_name(name)) for name in resolved["issuer"]
+    ]
+    return resolved
+
+
+def diff_positions(current, prior):
+    """Quarter-over-quarter change per position.
+
+    Classifies each holding as a brand-new stake, an add, a trim or an exit —
+    new stakes and adds being the ones that signal fresh conviction.
+    """
+    columns = ["issuer", "cusip", "ticker", "value", "prior_value", "value_change", "action"]
+    if current is None or current.empty:
+        return pd.DataFrame(columns=columns)
+
+    prior_by_cusip = (
+        prior.set_index("cusip")["value"] if prior is not None and not prior.empty
+        else pd.Series(dtype=float)
+    )
+    merged = current.copy()
+    merged["prior_value"] = merged["cusip"].map(prior_by_cusip).fillna(0.0)
+    merged["value_change"] = merged["value"] - merged["prior_value"]
+
+    def label(row):
+        if row["prior_value"] == 0 and row["value"] > 0:
+            return "New"
+        if row["value_change"] > 0:
+            return "Added"
+        if row["value_change"] < 0:
+            return "Trimmed"
+        return "Held"
+
+    merged["action"] = merged.apply(label, axis=1)
+    return merged.reindex(columns=columns)
+
+
+def summarize_insider_buys(transactions, since=None):
+    """Open-market insider purchases only, newest first.
+
+    Grants, option exercises and tax-withholding sales are dropped: they are
+    scheduled compensation events and say nothing about conviction.
+    """
+    columns = ["ticker", "owner", "role", "transaction_date", "shares", "price", "value"]
+    if not transactions:
+        return pd.DataFrame(columns=columns)
+
+    df = pd.DataFrame(transactions)
+    if df.empty or "code" not in df.columns:
+        return pd.DataFrame(columns=columns)
+
+    buys = df[(df["code"] == INSIDER_BUY_CODE) & (df["acquired"] == "A")].copy()
+    if buys.empty:
+        return pd.DataFrame(columns=columns)
+
+    buys["transaction_date"] = pd.to_datetime(buys["transaction_date"], errors="coerce")
+    buys = buys.dropna(subset=["transaction_date"])
+    if since is not None:
+        buys = buys[buys["transaction_date"] >= pd.Timestamp(since)]
+    if buys.empty:
+        return pd.DataFrame(columns=columns)
+    return (
+        buys.reindex(columns=columns)
+        .sort_values("transaction_date", ascending=False)
+        .reset_index(drop=True)
+    )
+
+
+# --- Network wrappers ----------------------------------------------------
+
+@st.cache_data(ttl=86400)
+def get_ticker_cik_map():
+    """Ticker -> {cik, title} for every EDGAR-registered company."""
+    payload = _get(COMPANY_TICKERS_URL)
+    if payload is None:
+        return {}
+    try:
+        raw = json.loads(payload.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return {}
+    return {
+        str(entry["ticker"]).upper(): {
+            "cik": int(entry["cik_str"]), "title": str(entry["title"]),
+        }
+        for entry in raw.values()
+        if isinstance(entry, dict) and entry.get("ticker")
+    }
+
+
+@st.cache_data(ttl=21600)
+def get_recent_filings(cik, forms):
+    """Recent filings of the given form types for one CIK."""
+    columns = ["form", "accession", "filing_date", "report_date", "document"]
+    payload = _get(SUBMISSIONS_URL.format(cik=int(cik)))
+    if payload is None:
+        return pd.DataFrame(columns=columns)
+    try:
+        recent = json.loads(payload.decode("utf-8")).get("filings", {}).get("recent", {})
+    except (ValueError, UnicodeDecodeError, AttributeError):
+        return pd.DataFrame(columns=columns)
+    if not recent or "form" not in recent:
+        return pd.DataFrame(columns=columns)
+
+    df = pd.DataFrame({
+        "form": recent.get("form", []),
+        "accession": recent.get("accessionNumber", []),
+        "filing_date": recent.get("filingDate", []),
+        "report_date": recent.get("reportDate", []),
+        "document": recent.get("primaryDocument", []),
+    })
+    return df[df["form"].isin(list(forms))].reset_index(drop=True)
+
+
+@st.cache_data(ttl=21600)
+def get_insider_buys(tickers, days=90, max_filings_per_ticker=40):
+    """Open-market insider purchases across a small set of tickers.
+
+    Scoped intentionally: one theme's constituents at a time. Scanning the
+    whole universe would mean thousands of Form 4 fetches.
+    """
+    cik_map = get_ticker_cik_map()
+    if not cik_map:
+        return pd.DataFrame()
+
+    since = date.today() - timedelta(days=days)
+    transactions = []
+    for ticker in tickers:
+        entry = cik_map.get(str(ticker).upper())
+        if entry is None:
+            continue
+        cik = entry["cik"]
+        filings = get_recent_filings(cik, ["4"])
+        if filings.empty:
+            continue
+        filings = filings[filings["filing_date"] >= since.isoformat()]
+        for _, filing in filings.head(max_filings_per_ticker).iterrows():
+            document = str(filing["document"])
+            # primaryDocument often points at the XSL-rendered view; the raw
+            # XML sits alongside it without the stylesheet directory prefix.
+            document = document.rsplit("/", 1)[-1]
+            url = ARCHIVES_URL.format(
+                cik=cik, accession=str(filing["accession"]).replace("-", ""),
+            ) + "/" + document
+            transactions.extend(parse_form4_xml(_get(url)))
+
+    return summarize_insider_buys(transactions, since=since)
+
+
+@st.cache_data(ttl=86400)
+def get_manager_positions(cik):
+    """Latest and prior 13F holdings for one manager, values in dollars.
+
+    Returns (current, prior, report_date, prior_report_date).
+    """
+    empty = pd.DataFrame(columns=["issuer", "cusip", "value", "shares"])
+    filings = get_recent_filings(cik, ["13F-HR"])
+    if filings.empty:
+        return empty, empty, None, None
+
+    filings = filings.sort_values("report_date", ascending=False)
+    snapshots = []
+    for _, filing in filings.head(2).iterrows():
+        accession = str(filing["accession"]).replace("-", "")
+        base = ARCHIVES_URL.format(cik=int(cik), accession=accession)
+        listing = _get(base + "/")
+        table_name = "infotable.xml"
+        if listing is not None:
+            names = re.findall(r'href="[^"]*/([^"/]+\.xml)"', listing.decode("utf-8", "ignore"))
+            candidates = [n for n in names if n.lower() != "primary_doc.xml"]
+            if candidates:
+                table_name = candidates[0]
+        positions = parse_infotable_xml(_get(f"{base}/{table_name}"))
+        report_date = pd.to_datetime(filing["report_date"], errors="coerce")
+        snapshots.append((
+            normalize_position_values(
+                positions, report_date.date() if pd.notna(report_date) else None,
+            ),
+            filing["report_date"],
+        ))
+
+    current, current_date = snapshots[0] if snapshots else (empty, None)
+    prior, prior_date = snapshots[1] if len(snapshots) > 1 else (empty, None)
+    return current, prior, current_date, prior_date

--- a/common/smart_money.py
+++ b/common/smart_money.py
@@ -1,0 +1,493 @@
+"""Thematic accumulation signals for the Smart Money Radar.
+
+Pure math with no Streamlit imports so the whole scoring pipeline stays
+unit-testable (same convention as ``common.dates`` and ``common.options``).
+
+The design goal is to surface themes *before* they boom. Ranking by trailing
+return only ever surfaces what already worked, so the composite weights
+accumulation evidence — money flow, dollar-volume expansion, broadening
+participation — far above realized return, and the stage classifier
+separates "capital arriving while price is still based" from "already run".
+"""
+
+import numpy as np
+import pandas as pd
+
+TRADING_DAYS = 252
+RS_WINDOWS = {"1M": 21, "3M": 63, "6M": 126}
+
+CMF_WINDOW = 21
+BREADTH_MA = 50
+BREADTH_LOOKBACK = 21
+THRUST_RECENT = 20
+THRUST_BASELINE = 100
+
+# Minimum bars a theme needs before its signals are trustworthy enough to rank.
+MIN_BARS = 130
+
+# Composite weights. Trailing relative strength is deliberately the smallest
+# term — the page exists to find themes before the return shows up.
+SCORE_WEIGHTS = {
+    "cmf": 0.30,
+    "dv_thrust": 0.25,
+    "rs_accel": 0.20,
+    "breadth_chg": 0.15,
+    "rs_3m": 0.10,
+}
+
+# Accumulation score excludes trailing return entirely: pure "is money
+# arriving right now" evidence, which is what the quadrant chart plots.
+ACCUM_WEIGHTS = {
+    "cmf": 0.40,
+    "dv_thrust": 0.35,
+    "breadth_chg": 0.25,
+}
+
+STAGE_CROWDED = "⚠️ Crowded / Extended"
+STAGE_MOMENTUM = "🔥 Momentum"
+STAGE_EARLY = "🚀 Early Trend"
+STAGE_ACCUMULATION = "🌱 Accumulation"
+STAGE_DORMANT = "💤 Dormant"
+
+# Best-to-worst for display ordering, not a ranking of desirability.
+STAGE_ORDER = [
+    STAGE_ACCUMULATION,
+    STAGE_EARLY,
+    STAGE_MOMENTUM,
+    STAGE_CROWDED,
+    STAGE_DORMANT,
+]
+
+# The stages the watchlist panel treats as "worth knowing about early".
+EARLY_STAGES = frozenset({STAGE_ACCUMULATION, STAGE_EARLY})
+
+
+# --- Basket construction -------------------------------------------------
+
+def equal_weight_index(close):
+    """Equal-weighted basket index (start = 1.0) from constituent closes.
+
+    Averages daily returns cross-sectionally rather than averaging prices, so
+    a constituent that lists late or has gaps joins the basket cleanly instead
+    of creating a step change in the index level.
+    """
+    if close is None or close.empty:
+        return pd.Series(dtype=float)
+    returns = close.pct_change()
+    basket = returns.mean(axis=1, skipna=True)
+    if basket.dropna().empty:
+        return pd.Series(0.0, index=close.index, dtype=float) + 1.0
+    return (1 + basket.fillna(0)).cumprod()
+
+
+def reindex_to_calendar(frame, calendar, ffill=False):
+    """Align a frame/series to a reference trading calendar.
+
+    Crypto trades every day while equities do not. Putting every theme on the
+    benchmark's calendar makes window lengths (21/63/126 bars) mean the same
+    elapsed time everywhere. Prices are forward-filled; volumes are not,
+    because carrying a volume figure forward would double-count it.
+    """
+    if frame is None or len(frame) == 0:
+        return frame
+    aligned = frame.reindex(calendar)
+    return aligned.ffill() if ffill else aligned
+
+
+# --- Individual signals --------------------------------------------------
+
+def chaikin_money_flow(high, low, close, volume, window=CMF_WINDOW):
+    """Chaikin Money Flow per constituent — accumulation vs distribution.
+
+    Money-flow multiplier weights each bar's volume by where the close landed
+    inside the bar's range: closing near the high on heavy volume reads as
+    accumulation. Bars with no range (high == low) contribute nothing rather
+    than dividing by zero.
+    """
+    if close is None or close.empty:
+        return pd.DataFrame()
+    span = high - low
+    multiplier = ((close - low) - (high - close)) / span.where(span != 0)
+    flow_volume = (multiplier * volume).where(span != 0)
+    flow_sum = flow_volume.rolling(window, min_periods=max(2, window // 2)).sum()
+    volume_sum = volume.where(span != 0).rolling(
+        window, min_periods=max(2, window // 2)
+    ).sum()
+    return flow_sum / volume_sum.where(volume_sum != 0)
+
+
+def dollar_volume_thrust(close, volume, recent=THRUST_RECENT, baseline=THRUST_BASELINE):
+    """Recent basket dollar volume versus its prior baseline, as a ratio - 1.
+
+    Sustained expansion in traded value is the cleanest free footprint of
+    institutional accumulation: size has to print somewhere.
+    """
+    if close is None or close.empty or volume is None or volume.empty:
+        return np.nan
+    dollar_volume = (close * volume).sum(axis=1, skipna=True).dropna()
+    if len(dollar_volume) < recent + 10:
+        return np.nan
+    recent_mean = dollar_volume.iloc[-recent:].mean()
+    base_slice = dollar_volume.iloc[-(recent + baseline):-recent]
+    if base_slice.empty:
+        return np.nan
+    base_mean = base_slice.mean()
+    if not np.isfinite(base_mean) or base_mean <= 0:
+        return np.nan
+    return recent_mean / base_mean - 1
+
+
+def _window_return(series, window):
+    """Simple return over the trailing ``window`` bars, NaN if too short."""
+    clean = series.dropna()
+    if len(clean) <= window:
+        return np.nan
+    start, end = clean.iloc[-1 - window], clean.iloc[-1]
+    if not np.isfinite(start) or start <= 0:
+        return np.nan
+    return end / start - 1
+
+
+def relative_strength(theme_index, benchmark, window):
+    """Theme return minus benchmark return over ``window`` bars."""
+    theme_ret = _window_return(theme_index, window)
+    bench_ret = _window_return(benchmark, window)
+    if not np.isfinite(theme_ret) or not np.isfinite(bench_ret):
+        return np.nan
+    return theme_ret - bench_ret
+
+
+def rs_acceleration(theme_index, benchmark, short=RS_WINDOWS["1M"], long=RS_WINDOWS["6M"]):
+    """Per-bar short-horizon RS minus per-bar long-horizon RS.
+
+    Positive means outperformance is building faster now than it has over the
+    longer window — the inflection that precedes a crowded trend.
+    """
+    short_rs = relative_strength(theme_index, benchmark, short)
+    long_rs = relative_strength(theme_index, benchmark, long)
+    if not np.isfinite(short_rs) or not np.isfinite(long_rs):
+        return np.nan
+    return short_rs / short - long_rs / long
+
+
+def breadth_above_ma(close, window=BREADTH_MA):
+    """Fraction of constituents trading above their ``window``-bar average."""
+    if close is None or close.empty:
+        return pd.Series(dtype=float)
+    moving_average = close.rolling(window, min_periods=max(5, window // 2)).mean()
+    above = close > moving_average
+    valid = close.notna() & moving_average.notna()
+    counts = valid.sum(axis=1)
+    return (above & valid).sum(axis=1).where(counts > 0) / counts.where(counts > 0)
+
+
+def pct_from_high(series, window=TRADING_DAYS):
+    """Distance below the trailing high, as a non-positive fraction."""
+    clean = series.dropna()
+    if clean.empty:
+        return np.nan
+    peak = clean.iloc[-window:].max()
+    if not np.isfinite(peak) or peak <= 0:
+        return np.nan
+    return clean.iloc[-1] / peak - 1
+
+
+# --- Cross-sectional scoring --------------------------------------------
+
+def cross_sectional_z(values, clip=3.0):
+    """Z-score a signal across themes at a single point in time.
+
+    Cross-sectional (not time-series) so no future information can leak in.
+    A degenerate spread returns zeros instead of dividing by zero, and the
+    result is clipped so one runaway theme cannot dominate the composite.
+    """
+    series = pd.Series(values, dtype=float)
+    if series.dropna().empty:
+        return pd.Series(0.0, index=series.index)
+    spread = series.std(ddof=0)
+    if not np.isfinite(spread) or spread == 0:
+        return pd.Series(0.0, index=series.index)
+    return ((series - series.mean()) / spread).clip(-clip, clip).fillna(0.0)
+
+
+def squash(raw):
+    """Map an unbounded weighted z-score onto a readable 0-100 scale."""
+    return 50 + 50 * np.tanh(raw)
+
+
+def classify_stage(row):
+    """Label a theme's position in the accumulation -> crowding lifecycle.
+
+    Order matters: extension is checked first so a theme that has already
+    tripled cannot be sold back to the user as "momentum" once its breadth
+    or acceleration has started to roll over.
+    """
+    accum = row.get("accum_score", np.nan)
+    rs_3m = row.get("rs_3m", np.nan)
+    accel = row.get("rs_accel", np.nan)
+    breadth = row.get("breadth", np.nan)
+    from_high = row.get("from_52w_high", np.nan)
+    run_12m = row.get("run_12m", np.nan)
+
+    extended = (
+        np.isfinite(from_high) and np.isfinite(run_12m)
+        and from_high > -0.05 and run_12m > 0.60
+    )
+    if extended and (
+        (np.isfinite(accel) and accel <= 0) or (np.isfinite(breadth) and breadth < 0.5)
+    ):
+        return STAGE_CROWDED
+    if (
+        np.isfinite(rs_3m) and rs_3m > 0.05
+        and np.isfinite(accel) and accel > 0
+        and np.isfinite(breadth) and breadth >= 0.6
+    ):
+        return STAGE_MOMENTUM
+    if (
+        np.isfinite(accum) and accum >= 60
+        and np.isfinite(accel) and accel > 0
+        and np.isfinite(rs_3m) and rs_3m > -0.02
+        and not extended
+    ):
+        return STAGE_EARLY
+    if np.isfinite(accum) and accum >= 60 and np.isfinite(rs_3m) and rs_3m <= 0.05:
+        return STAGE_ACCUMULATION
+    return STAGE_DORMANT
+
+
+# --- Pipeline ------------------------------------------------------------
+
+def theme_raw_signals(frames, benchmark):
+    """Raw (un-scored) signals for one theme from its OHLCV frames.
+
+    ``frames`` is a dict of field name -> DataFrame (Close/High/Low/Volume),
+    each indexed by date with one column per constituent.
+    """
+    close = frames.get("Close")
+    if close is None or close.empty:
+        return None
+
+    calendar = benchmark.index
+    # Count genuine observations before forward-filling: a theme that only
+    # traded for part of the calendar would otherwise have its last price
+    # carried across every remaining bar and look like a full history.
+    observed = int(reindex_to_calendar(close, calendar).notna().any(axis=1).sum())
+    close = reindex_to_calendar(close, calendar, ffill=True).dropna(how="all")
+    if close.empty:
+        return None
+    high = reindex_to_calendar(frames.get("High"), calendar, ffill=True)
+    low = reindex_to_calendar(frames.get("Low"), calendar, ffill=True)
+    volume = reindex_to_calendar(frames.get("Volume"), calendar)
+
+    index = equal_weight_index(close)
+    breadth_series = breadth_above_ma(close)
+    breadth_now = breadth_series.dropna().iloc[-1] if not breadth_series.dropna().empty else np.nan
+    breadth_prior = (
+        breadth_series.dropna().iloc[-1 - BREADTH_LOOKBACK]
+        if len(breadth_series.dropna()) > BREADTH_LOOKBACK
+        else np.nan
+    )
+
+    cmf_now = np.nan
+    if high is not None and low is not None and volume is not None:
+        cmf = chaikin_money_flow(high, low, close, volume)
+        if not cmf.empty:
+            latest = cmf.dropna(how="all")
+            if not latest.empty:
+                cmf_now = latest.iloc[-1].mean(skipna=True)
+
+    return {
+        "constituents": int(close.notna().any().sum()),
+        "bars": observed,
+        "theme_index": index,
+        "breadth_series": breadth_series,
+        "rs_1m": relative_strength(index, benchmark, RS_WINDOWS["1M"]),
+        "rs_3m": relative_strength(index, benchmark, RS_WINDOWS["3M"]),
+        "rs_6m": relative_strength(index, benchmark, RS_WINDOWS["6M"]),
+        "rs_accel": rs_acceleration(index, benchmark),
+        "dv_thrust": dollar_volume_thrust(close, volume),
+        "cmf": cmf_now,
+        "breadth": breadth_now,
+        "breadth_chg": breadth_now - breadth_prior
+        if np.isfinite(breadth_now) and np.isfinite(breadth_prior) else np.nan,
+        "from_52w_high": pct_from_high(index),
+        "run_12m": _window_return(index, TRADING_DAYS),
+    }
+
+
+def build_theme_signals(theme_frames, benchmark, min_constituents=3, min_bars=MIN_BARS):
+    """Score every theme and label its lifecycle stage.
+
+    ``theme_frames`` maps theme slug -> {field: DataFrame}. Nothing is fetched
+    here, which keeps the whole pipeline testable against synthetic frames.
+
+    Themes with too little history or too few surviving constituents are kept
+    in the output (so the page can report them) but excluded from the
+    cross-sectional statistics, where they would otherwise distort the mean.
+    """
+    benchmark = benchmark.dropna() if benchmark is not None else pd.Series(dtype=float)
+    if benchmark.empty or not theme_frames:
+        return pd.DataFrame()
+
+    rows, series = {}, {}
+    for slug, frames in theme_frames.items():
+        raw = theme_raw_signals(frames, benchmark)
+        if raw is None:
+            continue
+        series[slug] = {
+            "theme_index": raw.pop("theme_index"),
+            "breadth_series": raw.pop("breadth_series"),
+        }
+        rows[slug] = raw
+
+    if not rows:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(rows).T
+    for column in df.columns:
+        df[column] = pd.to_numeric(df[column], errors="coerce")
+
+    df["rankable"] = (df["constituents"] >= min_constituents) & (df["bars"] >= min_bars)
+
+    rankable = df.index[df["rankable"].astype(bool)]
+    scored = df.loc[rankable] if len(rankable) else df.iloc[0:0]
+
+    accum_raw = pd.Series(0.0, index=scored.index)
+    for signal, weight in ACCUM_WEIGHTS.items():
+        accum_raw += weight * cross_sectional_z(scored[signal])
+    df["accum_score"] = squash(accum_raw).reindex(df.index)
+
+    score_raw = pd.Series(0.0, index=scored.index)
+    for signal, weight in SCORE_WEIGHTS.items():
+        score_raw += weight * cross_sectional_z(scored[signal])
+    df["smart_money_score"] = squash(score_raw).reindex(df.index)
+
+    df["stage"] = [
+        classify_stage(row) if row["rankable"] else STAGE_DORMANT
+        for _, row in df.iterrows()
+    ]
+    df.attrs["series"] = series
+    return df.sort_values("smart_money_score", ascending=False)
+
+
+def truncate_frames(theme_frames, bars):
+    """Drop the last ``bars`` rows from every frame, for as-of recomputation.
+
+    The watchlist panel re-runs the whole pipeline on truncated data rather
+    than reusing today's z-scores, so the "30 days ago" snapshot cannot see
+    anything that had not happened yet.
+    """
+    if bars <= 0:
+        return theme_frames
+    return {
+        slug: {field: frame.iloc[:-bars] for field, frame in frames.items()
+               if frame is not None and len(frame) > bars}
+        for slug, frames in theme_frames.items()
+    }
+
+
+def diff_stages(now, before):
+    """Themes whose lifecycle stage changed between two snapshots."""
+    if now is None or now.empty or before is None or before.empty:
+        return pd.DataFrame(columns=["stage_before", "stage_now", "direction"])
+
+    shared = now.index.intersection(before.index)
+    records = []
+    for slug in shared:
+        was, is_now = before.loc[slug, "stage"], now.loc[slug, "stage"]
+        if was == is_now:
+            continue
+        if is_now in EARLY_STAGES and was not in EARLY_STAGES:
+            direction = "entering"
+        elif was in EARLY_STAGES and is_now == STAGE_MOMENTUM:
+            # The thesis played out: an early flag has been confirmed by price.
+            direction = "maturing"
+        elif was in EARLY_STAGES | {STAGE_MOMENTUM} and is_now in (STAGE_CROWDED, STAGE_DORMANT):
+            direction = "cooling"
+        else:
+            direction = "other"
+        records.append({
+            "theme": slug,
+            "stage_before": was,
+            "stage_now": is_now,
+            "direction": direction,
+        })
+    if not records:
+        return pd.DataFrame(columns=["stage_before", "stage_now", "direction"])
+    return pd.DataFrame(records).set_index("theme")
+
+
+def rotation_matrix(theme_indices, benchmark, freq="ME"):
+    """Per-period relative strength for every theme — the rotation heatmap.
+
+    Each cell is the theme's return minus the benchmark's return over that
+    calendar period, so reading across a row shows a narrative gaining and
+    losing sponsorship over time.
+    """
+    benchmark = benchmark.dropna() if benchmark is not None else pd.Series(dtype=float)
+    if benchmark.empty or not theme_indices:
+        return pd.DataFrame()
+
+    bench_periods = benchmark.resample(freq).last().pct_change().dropna()
+    if bench_periods.empty:
+        return pd.DataFrame()
+
+    rows = {}
+    for slug, index in theme_indices.items():
+        clean = index.dropna()
+        if clean.empty:
+            continue
+        theme_periods = clean.resample(freq).last().pct_change().dropna()
+        aligned = theme_periods.reindex(bench_periods.index)
+        rows[slug] = (aligned - bench_periods) * 100
+    if not rows:
+        return pd.DataFrame()
+    return pd.DataFrame(rows).T.dropna(axis=1, how="all")
+
+
+def constituent_table(frames, benchmark, window=RS_WINDOWS["3M"]):
+    """Per-name breakdown for the drill-down view of a single theme."""
+    close = frames.get("Close")
+    if close is None or close.empty:
+        return pd.DataFrame()
+
+    calendar = benchmark.index
+    close = reindex_to_calendar(close, calendar, ffill=True)
+    high = reindex_to_calendar(frames.get("High"), calendar, ffill=True)
+    low = reindex_to_calendar(frames.get("Low"), calendar, ffill=True)
+    volume = reindex_to_calendar(frames.get("Volume"), calendar)
+
+    cmf = (
+        chaikin_money_flow(high, low, close, volume)
+        if high is not None and low is not None and volume is not None
+        else pd.DataFrame()
+    )
+
+    rows = []
+    for ticker in close.columns:
+        prices = close[ticker].dropna()
+        if prices.empty:
+            continue
+        thrust = np.nan
+        if volume is not None and ticker in volume.columns:
+            thrust = dollar_volume_thrust(
+                close[[ticker]], volume[[ticker]]
+            )
+        latest_cmf = np.nan
+        if not cmf.empty and ticker in cmf.columns:
+            valid = cmf[ticker].dropna()
+            latest_cmf = valid.iloc[-1] if not valid.empty else np.nan
+        rows.append({
+            "Ticker": ticker,
+            "Last": prices.iloc[-1],
+            "Return 3M (%)": (_window_return(prices, window) or np.nan) * 100,
+            "RS vs Benchmark (%)": relative_strength(prices, benchmark, window) * 100,
+            "Dollar Vol Thrust (%)": thrust * 100 if np.isfinite(thrust) else np.nan,
+            "Money Flow (CMF)": latest_cmf,
+            "From 52w High (%)": pct_from_high(prices) * 100,
+        })
+    if not rows:
+        return pd.DataFrame()
+    return pd.DataFrame(rows).set_index("Ticker").sort_values(
+        "RS vs Benchmark (%)", ascending=False
+    )

--- a/common/themes.py
+++ b/common/themes.py
@@ -1,0 +1,162 @@
+"""Thematic basket definitions for the Smart Money Radar.
+
+Plain data with no imports, so the universe can be inspected and tested
+without pandas or a Streamlit runtime.
+
+Each theme is an equal-weighted basket of liquid, Yahoo-Finance-resolvable
+symbols that express one narrative. Baskets are deliberately small (6-9
+names): enough for breadth to mean something, few enough that a single
+delisting does not silently gut the signal.
+"""
+
+# slug -> {label, icon, asset_class, thesis, tickers}
+THEMES = {
+    "ai_compute": {
+        "label": "AI & Accelerated Compute",
+        "icon": "🧠",
+        "asset_class": "Equity",
+        "thesis": "Silicon, networking and thermal plumbing for training and inference clusters.",
+        "tickers": ["NVDA", "AMD", "AVGO", "TSM", "MU", "MRVL", "ARM", "ANET", "VRT"],
+    },
+    "ai_software": {
+        "label": "AI Software & Agents",
+        "icon": "🤖",
+        "asset_class": "Equity",
+        "thesis": "Application and platform layer monetizing models rather than selling chips.",
+        "tickers": ["MSFT", "PLTR", "NOW", "SNOW", "CRM", "DDOG", "MDB"],
+    },
+    "semi_equipment": {
+        "label": "Semiconductor Equipment",
+        "icon": "🔬",
+        "asset_class": "Equity",
+        "thesis": "Toolmakers that get paid on fab capex regardless of which chip designer wins.",
+        "tickers": ["ASML", "AMAT", "LRCX", "KLAC", "TER", "ONTO"],
+    },
+    "crypto_equities": {
+        "label": "Crypto Equities",
+        "icon": "⛓️",
+        "asset_class": "Equity",
+        "thesis": "Listed proxies for digital-asset adoption: exchanges, miners, treasuries.",
+        "tickers": ["COIN", "MSTR", "MARA", "RIOT", "CLSK", "HOOD", "HUT"],
+    },
+    "crypto_spot": {
+        "label": "Digital Assets (Spot)",
+        "icon": "🪙",
+        "asset_class": "Crypto",
+        "thesis": "The underlying tokens themselves — the purest read on crypto risk appetite.",
+        "tickers": ["BTC-USD", "ETH-USD", "SOL-USD", "LINK-USD", "AVAX-USD", "XRP-USD"],
+    },
+    "nuclear_uranium": {
+        "label": "Nuclear & Uranium",
+        "icon": "☢️",
+        "asset_class": "Equity",
+        "thesis": "Fuel cycle and small modular reactors as firm power for datacenter load.",
+        "tickers": ["CCJ", "LEU", "SMR", "OKLO", "BWXT", "UEC", "NNE"],
+    },
+    "power_grid": {
+        "label": "Power & Grid Buildout",
+        "icon": "⚡",
+        "asset_class": "Equity",
+        "thesis": "Generation and transmission bottleneck — the physical constraint on AI scaling.",
+        "tickers": ["VST", "CEG", "NRG", "GEV", "ETN", "PWR", "POWL"],
+    },
+    "quantum": {
+        "label": "Quantum Computing",
+        "icon": "🧬",
+        "asset_class": "Equity",
+        "thesis": "Pre-revenue optionality; moves violently on research and funding headlines.",
+        "tickers": ["IONQ", "RGTI", "QBTS", "QUBT"],
+    },
+    "space_defense": {
+        "label": "Space & Defense Tech",
+        "icon": "🚀",
+        "asset_class": "Equity",
+        "thesis": "Launch, satellite constellations and autonomous defense procurement.",
+        "tickers": ["RKLB", "ASTS", "LUNR", "AVAV", "KTOS", "LMT", "RTX"],
+    },
+    "cybersecurity": {
+        "label": "Cybersecurity",
+        "icon": "🛡️",
+        "asset_class": "Equity",
+        "thesis": "Non-discretionary software spend; tends to lead in risk-off software tape.",
+        "tickers": ["CRWD", "PANW", "ZS", "S", "FTNT", "OKTA"],
+    },
+    "robotics": {
+        "label": "Robotics & Automation",
+        "icon": "🦾",
+        "asset_class": "Equity",
+        "thesis": "Physical AI: warehouse, surgical and industrial automation.",
+        "tickers": ["ISRG", "ROK", "SYM", "TER", "NDSN", "ZBRA"],
+    },
+    "obesity_biotech": {
+        "label": "GLP-1 & Obesity",
+        "icon": "💊",
+        "asset_class": "Equity",
+        "thesis": "Incretin franchise plus the telehealth channel distributing it.",
+        "tickers": ["LLY", "NVO", "VKTX", "AMGN", "HIMS", "ZLDPF"],
+    },
+    "rare_earths": {
+        "label": "Rare Earths & Critical Minerals",
+        "icon": "⛏️",
+        "asset_class": "Equity",
+        "thesis": "Supply-chain onshoring of magnet, lithium and copper feedstock.",
+        "tickers": ["MP", "ALB", "FCX", "SCCO", "UEC", "TMC"],
+    },
+    "clean_energy": {
+        "label": "Clean Energy & Solar",
+        "icon": "🌞",
+        "asset_class": "Equity",
+        "thesis": "Rate-sensitive renewables; a classic deep-base candidate after long drawdowns.",
+        "tickers": ["ENPH", "FSLR", "RUN", "NEE", "SEDG", "ARRY"],
+    },
+    "evtol": {
+        "label": "eVTOL & Advanced Air Mobility",
+        "icon": "🛩️",
+        "asset_class": "Equity",
+        "thesis": "Certification-gated aviation startups; binary newsflow, heavy retail float.",
+        "tickers": ["JOBY", "ACHR", "EH", "RCAT"],
+    },
+    "precious_metals": {
+        "label": "Precious Metals & Debasement",
+        "icon": "🥇",
+        "asset_class": "Commodity",
+        "thesis": "Metal plus the miners' operating leverage — the fiat-debasement expression.",
+        "tickers": ["GC=F", "SI=F", "NEM", "GOLD", "AEM", "WPM"],
+    },
+}
+
+# Minimum constituents that must return usable data for a theme to be ranked.
+MIN_CONSTITUENTS = 3
+
+
+def all_tickers():
+    """Every unique symbol across all themes, in stable order."""
+    seen = {}
+    for theme in THEMES.values():
+        for ticker in theme["tickers"]:
+            seen[ticker] = None
+    return list(seen)
+
+
+def asset_classes():
+    """Distinct asset classes present in the universe, sorted."""
+    return sorted({theme["asset_class"] for theme in THEMES.values()})
+
+
+def themes_by_asset_class(asset_class):
+    """Themes filtered to one asset class, or all themes when None/'All'."""
+    if asset_class in (None, "All"):
+        return dict(THEMES)
+    return {
+        slug: theme
+        for slug, theme in THEMES.items()
+        if theme["asset_class"] == asset_class
+    }
+
+
+def theme_label(slug):
+    """Display label with icon for a theme slug."""
+    theme = THEMES.get(slug)
+    if theme is None:
+        return slug
+    return f"{theme['icon']} {theme['label']}"

--- a/tests/test_sec_edgar.py
+++ b/tests/test_sec_edgar.py
@@ -1,0 +1,291 @@
+"""Tests for the EDGAR parsing layer. Nothing here touches the network."""
+
+import pandas as pd
+import pytest
+
+from common.sec_edgar import (
+    CURATED_MANAGERS,
+    DEFAULT_CONTACT_EMAIL,
+    build_issuer_ticker_map,
+    diff_positions,
+    map_positions_to_tickers,
+    normalize_issuer_name,
+    normalize_position_values,
+    parse_form4_xml,
+    parse_infotable_xml,
+    summarize_insider_buys,
+    _user_agent,
+)
+
+# Shape mirrors a real ownership form: transaction fields are wrapped in a
+# <value> child, which is what makes the parsing non-obvious.
+FORM4_XML = b"""<?xml version="1.0"?>
+<ownershipDocument>
+  <issuer><issuerTradingSymbol>MP</issuerTradingSymbol></issuer>
+  <reportingOwner>
+    <reportingOwnerId><rptOwnerName>Rosenthal Michael Stuart</rptOwnerName></reportingOwnerId>
+    <reportingOwnerRelationship>
+      <isOfficer>1</isOfficer>
+      <officerTitle>Chief Operating Officer</officerTitle>
+    </reportingOwnerRelationship>
+  </reportingOwner>
+  <nonDerivativeTable>
+    <nonDerivativeTransaction>
+      <transactionDate><value>2026-06-09</value></transactionDate>
+      <transactionCoding><transactionCode>P</transactionCode></transactionCoding>
+      <transactionAmounts>
+        <transactionShares><value>10000</value></transactionShares>
+        <transactionPricePerShare><value>54.30</value></transactionPricePerShare>
+        <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+      </transactionAmounts>
+    </nonDerivativeTransaction>
+    <nonDerivativeTransaction>
+      <transactionDate><value>2026-06-10</value></transactionDate>
+      <transactionCoding><transactionCode>A</transactionCode></transactionCoding>
+      <transactionAmounts>
+        <transactionShares><value>1262</value></transactionShares>
+        <transactionPricePerShare><value>0</value></transactionPricePerShare>
+        <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+      </transactionAmounts>
+    </nonDerivativeTransaction>
+    <nonDerivativeTransaction>
+      <transactionDate><value>2026-06-11</value></transactionDate>
+      <transactionCoding><transactionCode>S</transactionCode></transactionCoding>
+      <transactionAmounts>
+        <transactionShares><value>500</value></transactionShares>
+        <transactionPricePerShare><value>60.00</value></transactionPricePerShare>
+        <transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode>
+      </transactionAmounts>
+    </nonDerivativeTransaction>
+  </nonDerivativeTable>
+</ownershipDocument>
+"""
+
+# Real 13F info tables are namespaced; the parser must be namespace-agnostic.
+INFOTABLE_XML = b"""<?xml version="1.0"?>
+<informationTable xmlns="http://www.sec.gov/edgar/document/thirteenf/informationtable">
+  <infoTable>
+    <nameOfIssuer>NVIDIA CORPORATION</nameOfIssuer>
+    <cusip>67066G104</cusip>
+    <value>773586958</value>
+    <shrsOrPrnAmt><sshPrnamt>4000000</sshPrnamt></shrsOrPrnAmt>
+  </infoTable>
+  <infoTable>
+    <nameOfIssuer>BROADCOM INC</nameOfIssuer>
+    <cusip>11135F101</cusip>
+    <value>497845413</value>
+    <shrsOrPrnAmt><sshPrnamt>1500000</sshPrnamt></shrsOrPrnAmt>
+  </infoTable>
+  <infoTable>
+    <nameOfIssuer>NVIDIA CORPORATION</nameOfIssuer>
+    <cusip>67066G104</cusip>
+    <value>1000000</value>
+    <shrsOrPrnAmt><sshPrnamt>5000</sshPrnamt></shrsOrPrnAmt>
+  </infoTable>
+</informationTable>
+"""
+
+
+class TestUserAgent:
+    def test_declares_a_contact_address(self):
+        # SEC rejects a User-Agent that carries a URL instead of an email.
+        assert "@" in _user_agent()
+        assert "http" not in _user_agent()
+
+    def test_deployer_can_override_the_contact(self, monkeypatch):
+        monkeypatch.setenv("SEC_CONTACT_EMAIL", "ops@fund.test")
+        assert "ops@fund.test" in _user_agent()
+
+    def test_falls_back_to_the_placeholder_when_unset(self, monkeypatch):
+        monkeypatch.delenv("SEC_CONTACT_EMAIL", raising=False)
+        assert DEFAULT_CONTACT_EMAIL in _user_agent()
+
+    def test_blank_override_falls_back(self, monkeypatch):
+        monkeypatch.setenv("SEC_CONTACT_EMAIL", "   ")
+        assert DEFAULT_CONTACT_EMAIL in _user_agent()
+
+
+class TestParseForm4:
+    def test_extracts_every_non_derivative_transaction(self):
+        assert len(parse_form4_xml(FORM4_XML)) == 3
+
+    def test_unwraps_nested_value_elements(self):
+        # The wrapper elements carry no text of their own; reading them
+        # directly yields blanks and silently drops every transaction.
+        buy = parse_form4_xml(FORM4_XML)[0]
+        assert buy["shares"] == 10000.0
+        assert buy["price"] == pytest.approx(54.30)
+        assert buy["acquired"] == "A"
+        assert buy["transaction_date"] == "2026-06-09"
+
+    def test_computes_transaction_value(self):
+        assert parse_form4_xml(FORM4_XML)[0]["value"] == pytest.approx(543000.0)
+
+    def test_carries_issuer_and_owner_identity(self):
+        buy = parse_form4_xml(FORM4_XML)[0]
+        assert buy["ticker"] == "MP"
+        assert buy["owner"] == "Rosenthal Michael Stuart"
+        assert buy["role"] == "Chief Operating Officer"
+
+    def test_malformed_xml_returns_empty(self):
+        assert parse_form4_xml(b"<not-xml") == []
+
+    def test_empty_payload_returns_empty(self):
+        assert parse_form4_xml(None) == []
+        assert parse_form4_xml(b"") == []
+
+
+class TestSummarizeInsiderBuys:
+    def test_keeps_only_open_market_purchases(self):
+        buys = summarize_insider_buys(parse_form4_xml(FORM4_XML))
+        assert len(buys) == 1
+        assert buys.iloc[0]["value"] == pytest.approx(543000.0)
+
+    def test_excludes_grants_and_sales(self):
+        # Codes A/M/F are compensation mechanics and vastly outnumber real
+        # purchases, so including them would drown out the signal.
+        buys = summarize_insider_buys(parse_form4_xml(FORM4_XML))
+        assert buys["value"].tolist() == [pytest.approx(543000.0)]
+
+    def test_since_filter_drops_older_transactions(self):
+        buys = summarize_insider_buys(parse_form4_xml(FORM4_XML), since="2026-07-01")
+        assert buys.empty
+
+    def test_no_transactions_returns_empty_frame(self):
+        assert summarize_insider_buys([]).empty
+
+    def test_result_is_sorted_newest_first(self):
+        doubled = parse_form4_xml(FORM4_XML) + [{
+            "ticker": "MP", "owner": "Someone", "role": "Director", "code": "P",
+            "acquired": "A", "shares": 1.0, "price": 1.0, "value": 1.0,
+            "transaction_date": "2026-08-01",
+        }]
+        dates = summarize_insider_buys(doubled)["transaction_date"]
+        assert dates.is_monotonic_decreasing
+
+
+class TestParseInfotable:
+    def test_parses_namespaced_positions(self):
+        positions = parse_infotable_xml(INFOTABLE_XML)
+        assert set(positions["cusip"]) == {"67066G104", "11135F101"}
+
+    def test_aggregates_duplicate_issuer_rows(self):
+        # Managers report the same issuer once per account; the page wants
+        # one line per position.
+        positions = parse_infotable_xml(INFOTABLE_XML)
+        nvda = positions[positions["cusip"] == "67066G104"].iloc[0]
+        assert nvda["value"] == pytest.approx(774586958.0)
+        assert nvda["shares"] == pytest.approx(4005000.0)
+
+    def test_malformed_xml_returns_empty_frame(self):
+        assert parse_infotable_xml(b"<broken").empty
+
+    def test_empty_payload_returns_empty_frame(self):
+        assert parse_infotable_xml(None).empty
+
+
+class TestNormalizeIssuerName:
+    @pytest.mark.parametrize("left,right", [
+        ("NVIDIA CORPORATION", "NVIDIA Corp"),
+        ("BROADCOM INC", "Broadcom Inc."),
+        ("ALPHABET INC CLASS A", "Alphabet Inc."),
+        ("ELI LILLY & CO", "ELI LILLY & Co"),
+        ("MICRON TECHNOLOGY INC", "Micron Technology, Inc."),
+    ])
+    def test_spelling_variants_collapse_together(self, left, right):
+        assert normalize_issuer_name(left) == normalize_issuer_name(right)
+
+    def test_distinct_companies_stay_distinct(self):
+        assert normalize_issuer_name("NVIDIA CORP") != normalize_issuer_name("BROADCOM INC")
+
+    def test_empty_input_returns_empty_string(self):
+        assert normalize_issuer_name(None) == ""
+        assert normalize_issuer_name("") == ""
+
+
+class TestPositionMapping:
+    @pytest.fixture
+    def issuer_map(self):
+        return build_issuer_ticker_map({
+            "NVDA": "NVIDIA CORP", "AVGO": "Broadcom Inc.", "MU": "Micron Technology, Inc.",
+        })
+
+    def test_resolves_known_issuers_to_tickers(self, issuer_map):
+        mapped = map_positions_to_tickers(parse_infotable_xml(INFOTABLE_XML), issuer_map)
+        assert set(mapped.dropna(subset=["ticker"])["ticker"]) == {"NVDA", "AVGO"}
+
+    def test_unmatched_issuers_keep_a_null_ticker(self):
+        mapped = map_positions_to_tickers(
+            parse_infotable_xml(INFOTABLE_XML), build_issuer_ticker_map({"MU": "Micron"}),
+        )
+        # Rows survive with no ticker so unmapped value stays visible.
+        assert len(mapped) == 2
+        assert mapped["ticker"].isna().all()
+
+    def test_empty_positions_return_a_ticker_column(self):
+        empty = pd.DataFrame(columns=["issuer", "cusip", "value", "shares"])
+        assert "ticker" in map_positions_to_tickers(empty, {}).columns
+
+
+class TestNormalizePositionValues:
+    def _positions(self):
+        return pd.DataFrame({"issuer": ["A"], "cusip": ["X"], "value": [1000.0], "shares": [1.0]})
+
+    def test_pre_2023_values_scale_from_thousands(self):
+        import datetime
+        scaled = normalize_position_values(self._positions(), datetime.date(2022, 6, 30))
+        assert scaled["value"].iloc[0] == pytest.approx(1_000_000.0)
+
+    def test_modern_values_are_left_in_dollars(self):
+        import datetime
+        scaled = normalize_position_values(self._positions(), datetime.date(2026, 6, 30))
+        assert scaled["value"].iloc[0] == pytest.approx(1000.0)
+
+    def test_missing_report_date_leaves_values_alone(self):
+        assert normalize_position_values(self._positions(), None)["value"].iloc[0] == 1000.0
+
+
+class TestDiffPositions:
+    def _frame(self, rows):
+        return pd.DataFrame(rows, columns=["issuer", "cusip", "ticker", "value"])
+
+    def test_absent_prior_position_is_new(self):
+        diff = diff_positions(
+            self._frame([["N", "1", "NVDA", 100.0]]), self._frame([]),
+        )
+        assert diff.iloc[0]["action"] == "New"
+
+    def test_increase_is_added(self):
+        diff = diff_positions(
+            self._frame([["N", "1", "NVDA", 150.0]]),
+            self._frame([["N", "1", "NVDA", 100.0]]),
+        )
+        assert diff.iloc[0]["action"] == "Added"
+        assert diff.iloc[0]["value_change"] == pytest.approx(50.0)
+
+    def test_decrease_is_trimmed(self):
+        diff = diff_positions(
+            self._frame([["N", "1", "NVDA", 60.0]]),
+            self._frame([["N", "1", "NVDA", 100.0]]),
+        )
+        assert diff.iloc[0]["action"] == "Trimmed"
+
+    def test_unchanged_is_held(self):
+        diff = diff_positions(
+            self._frame([["N", "1", "NVDA", 100.0]]),
+            self._frame([["N", "1", "NVDA", 100.0]]),
+        )
+        assert diff.iloc[0]["action"] == "Held"
+
+    def test_empty_current_returns_empty(self):
+        assert diff_positions(pd.DataFrame(), self._frame([])).empty
+
+
+class TestCuratedManagers:
+    def test_every_entry_has_a_numeric_cik_and_name(self):
+        for cik, name in CURATED_MANAGERS.items():
+            assert isinstance(cik, int) and 0 < cik < 10**10
+            assert isinstance(name, str) and name
+
+    def test_ciks_are_unique(self):
+        assert len(CURATED_MANAGERS) == len(set(CURATED_MANAGERS))

--- a/tests/test_smart_money.py
+++ b/tests/test_smart_money.py
@@ -1,0 +1,437 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from common.smart_money import (
+    STAGE_ACCUMULATION,
+    STAGE_CROWDED,
+    STAGE_DORMANT,
+    STAGE_EARLY,
+    STAGE_MOMENTUM,
+    breadth_above_ma,
+    build_theme_signals,
+    chaikin_money_flow,
+    classify_stage,
+    constituent_table,
+    cross_sectional_z,
+    diff_stages,
+    dollar_volume_thrust,
+    equal_weight_index,
+    pct_from_high,
+    relative_strength,
+    rotation_matrix,
+    rs_acceleration,
+    squash,
+    truncate_frames,
+)
+
+BARS = 400
+
+
+def _calendar(n=BARS):
+    return pd.bdate_range("2024-01-01", periods=n)
+
+
+def _frames(drift_per_bar, n=BARS, tickers=("AAA", "BBB", "CCC"),
+            volume=1_000_000, volume_multiplier=1.0, range_pct=0.02,
+            close_position=0.5):
+    """Synthetic OHLCV frames with a controllable trend and bar placement.
+
+    close_position 1.0 puts the close at the bar high (accumulation),
+    0.0 at the low (distribution).
+    """
+    index = _calendar(n)
+    close = pd.DataFrame(
+        {t: 100 * (1 + drift_per_bar) ** np.arange(n) for t in tickers}, index=index
+    )
+    span = close * range_pct
+    low = close - span * close_position
+    high = low + span
+    volumes = pd.DataFrame({t: float(volume) for t in tickers}, index=index)
+    if volume_multiplier != 1.0:
+        volumes.iloc[-20:] *= volume_multiplier
+    return {"Close": close, "High": high, "Low": low, "Volume": volumes}
+
+
+def _benchmark(drift_per_bar=0.0, n=BARS):
+    return pd.Series(
+        100 * (1 + drift_per_bar) ** np.arange(n), index=_calendar(n), dtype=float
+    )
+
+
+class TestEqualWeightIndex:
+    def test_tracks_a_uniform_basket(self):
+        close = _frames(0.001)["Close"]
+        index = equal_weight_index(close)
+        assert index.iloc[-1] == pytest.approx((1.001) ** (BARS - 1), rel=1e-6)
+
+    def test_averages_divergent_constituents(self):
+        index = pd.bdate_range("2024-01-01", periods=3)
+        close = pd.DataFrame({"UP": [100.0, 110.0, 121.0], "FLAT": [50.0, 50.0, 50.0]}, index=index)
+        # Daily returns average (10% + 0%)/2 = 5% per bar.
+        assert equal_weight_index(close).iloc[-1] == pytest.approx(1.05 ** 2)
+
+    def test_late_listing_does_not_step_the_index(self):
+        index = pd.bdate_range("2024-01-01", periods=4)
+        close = pd.DataFrame(
+            {"OLD": [100.0, 101.0, 102.0, 103.0], "NEW": [np.nan, np.nan, 500.0, 505.0]},
+            index=index,
+        )
+        values = equal_weight_index(close)
+        # The new listing joins via its return, so no jump when it appears.
+        assert values.is_monotonic_increasing
+        assert values.max() < 1.1
+
+    def test_empty_input_returns_empty(self):
+        assert equal_weight_index(pd.DataFrame()).empty
+
+
+class TestChaikinMoneyFlow:
+    def test_close_at_high_is_full_accumulation(self):
+        frames = _frames(0.0, close_position=1.0)
+        cmf = chaikin_money_flow(frames["High"], frames["Low"], frames["Close"], frames["Volume"])
+        assert cmf.iloc[-1].mean() == pytest.approx(1.0)
+
+    def test_close_at_low_is_full_distribution(self):
+        frames = _frames(0.0, close_position=0.0)
+        cmf = chaikin_money_flow(frames["High"], frames["Low"], frames["Close"], frames["Volume"])
+        assert cmf.iloc[-1].mean() == pytest.approx(-1.0)
+
+    def test_midrange_close_is_neutral(self):
+        frames = _frames(0.0, close_position=0.5)
+        cmf = chaikin_money_flow(frames["High"], frames["Low"], frames["Close"], frames["Volume"])
+        assert cmf.iloc[-1].mean() == pytest.approx(0.0, abs=1e-9)
+
+    def test_zero_range_bars_do_not_divide_by_zero(self):
+        index = pd.bdate_range("2024-01-01", periods=30)
+        flat = pd.DataFrame({"A": [100.0] * 30}, index=index)
+        volume = pd.DataFrame({"A": [1000.0] * 30}, index=index)
+        cmf = chaikin_money_flow(flat, flat, flat, volume)
+        assert not np.isinf(cmf.to_numpy(dtype=float)).any()
+        assert cmf["A"].dropna().empty
+
+    def test_empty_input_returns_empty(self):
+        empty = pd.DataFrame()
+        assert chaikin_money_flow(empty, empty, empty, empty).empty
+
+
+class TestDollarVolumeThrust:
+    def test_doubled_recent_volume_reads_as_plus_one(self):
+        frames = _frames(0.0, volume_multiplier=2.0)
+        assert dollar_volume_thrust(frames["Close"], frames["Volume"]) == pytest.approx(1.0)
+
+    def test_steady_volume_reads_as_zero(self):
+        frames = _frames(0.0)
+        assert dollar_volume_thrust(frames["Close"], frames["Volume"]) == pytest.approx(0.0)
+
+    def test_short_history_returns_nan(self):
+        frames = _frames(0.0, n=15)
+        assert np.isnan(dollar_volume_thrust(frames["Close"], frames["Volume"]))
+
+
+class TestRelativeStrength:
+    def test_outperformance_is_positive(self):
+        theme, bench = equal_weight_index(_frames(0.002)["Close"]), _benchmark(0.0)
+        assert relative_strength(theme, bench, 63) > 0
+
+    def test_matching_the_benchmark_is_zero(self):
+        theme, bench = equal_weight_index(_frames(0.001)["Close"]), _benchmark(0.001)
+        assert relative_strength(theme, bench, 63) == pytest.approx(0.0, abs=1e-9)
+
+    def test_window_longer_than_history_returns_nan(self):
+        theme, bench = equal_weight_index(_frames(0.001, n=30)["Close"]), _benchmark(0.0, 30)
+        assert np.isnan(relative_strength(theme, bench, 126))
+
+    def test_acceleration_positive_when_recent_move_is_faster(self):
+        close = _frames(0.0)["Close"]
+        # Flat for most of the window, then a sharp late advance.
+        close.iloc[-21:] *= np.linspace(1.0, 1.3, 21)[:, None]
+        assert rs_acceleration(equal_weight_index(close), _benchmark(0.0)) > 0
+
+    def test_acceleration_negative_when_trend_is_stalling(self):
+        close = _frames(0.003)["Close"]
+        close.iloc[-21:] = close.iloc[-22]  # advance stops dead
+        assert rs_acceleration(equal_weight_index(close), _benchmark(0.0)) < 0
+
+
+class TestBreadth:
+    def test_rising_basket_is_fully_above_its_average(self):
+        breadth = breadth_above_ma(_frames(0.002)["Close"])
+        assert breadth.iloc[-1] == pytest.approx(1.0)
+
+    def test_falling_basket_has_no_members_above_average(self):
+        breadth = breadth_above_ma(_frames(-0.002)["Close"])
+        assert breadth.iloc[-1] == pytest.approx(0.0)
+
+    def test_mixed_basket_is_partial(self):
+        index = _calendar()
+        close = pd.DataFrame({
+            "UP": 100 * 1.002 ** np.arange(BARS),
+            "DOWN": 100 * 0.998 ** np.arange(BARS),
+        }, index=index)
+        assert breadth_above_ma(close).iloc[-1] == pytest.approx(0.5)
+
+
+class TestPctFromHigh:
+    def test_at_the_high_is_zero(self):
+        assert pct_from_high(equal_weight_index(_frames(0.001)["Close"])) == pytest.approx(0.0)
+
+    def test_below_the_high_is_negative(self):
+        close = _frames(0.001)["Close"]
+        close.iloc[-1] *= 0.8
+        assert pct_from_high(equal_weight_index(close)) < 0
+
+    def test_empty_series_returns_nan(self):
+        assert np.isnan(pct_from_high(pd.Series(dtype=float)))
+
+
+class TestCrossSectionalZ:
+    def test_constant_input_returns_zeros_not_nan(self):
+        z = cross_sectional_z(pd.Series([5.0, 5.0, 5.0]))
+        assert (z == 0).all()
+
+    def test_all_nan_input_returns_zeros(self):
+        assert (cross_sectional_z(pd.Series([np.nan, np.nan])) == 0).all()
+
+    def test_ranking_is_preserved(self):
+        z = cross_sectional_z(pd.Series([1.0, 2.0, 3.0]))
+        assert z.iloc[0] < z.iloc[1] < z.iloc[2]
+
+    def test_outliers_are_clipped(self):
+        z = cross_sectional_z(pd.Series([0.0, 0.0, 0.0, 0.0, 1e9]), clip=3.0)
+        assert z.max() <= 3.0
+
+    def test_nan_members_score_neutral(self):
+        z = cross_sectional_z(pd.Series([1.0, 2.0, 3.0, np.nan]))
+        assert z.iloc[3] == 0.0
+
+
+class TestSquash:
+    def test_zero_maps_to_midpoint(self):
+        assert squash(0.0) == pytest.approx(50.0)
+
+    def test_output_stays_within_bounds(self):
+        assert 0 <= squash(-50) < 1
+        assert 99 < squash(50) <= 100
+
+    def test_is_monotonic(self):
+        assert squash(-1) < squash(0) < squash(1)
+
+
+class TestClassifyStage:
+    def test_flow_without_price_move_is_accumulation(self):
+        assert classify_stage({
+            "accum_score": 75, "rs_3m": 0.0, "rs_accel": -0.0001,
+            "breadth": 0.5, "from_52w_high": -0.20, "run_12m": 0.05,
+        }) == STAGE_ACCUMULATION
+
+    def test_flow_plus_inflection_is_early_trend(self):
+        assert classify_stage({
+            "accum_score": 70, "rs_3m": 0.03, "rs_accel": 0.001,
+            "breadth": 0.55, "from_52w_high": -0.10, "run_12m": 0.20,
+        }) == STAGE_EARLY
+
+    def test_broad_confirmed_advance_is_momentum(self):
+        assert classify_stage({
+            "accum_score": 55, "rs_3m": 0.25, "rs_accel": 0.002,
+            "breadth": 0.85, "from_52w_high": -0.02, "run_12m": 0.40,
+        }) == STAGE_MOMENTUM
+
+    def test_extended_run_with_stalling_acceleration_is_crowded(self):
+        assert classify_stage({
+            "accum_score": 65, "rs_3m": 0.30, "rs_accel": -0.001,
+            "breadth": 0.8, "from_52w_high": -0.01, "run_12m": 1.50,
+        }) == STAGE_CROWDED
+
+    def test_extension_outranks_momentum(self):
+        # Strong trailing numbers must not relabel a narrowing, extended
+        # theme as momentum — that is the failure mode the page exists to avoid.
+        assert classify_stage({
+            "accum_score": 80, "rs_3m": 0.40, "rs_accel": 0.003,
+            "breadth": 0.30, "from_52w_high": -0.01, "run_12m": 2.0,
+        }) == STAGE_CROWDED
+
+    def test_nothing_firing_is_dormant(self):
+        assert classify_stage({
+            "accum_score": 30, "rs_3m": -0.10, "rs_accel": -0.001,
+            "breadth": 0.2, "from_52w_high": -0.40, "run_12m": -0.30,
+        }) == STAGE_DORMANT
+
+    def test_all_nan_row_is_dormant(self):
+        assert classify_stage({k: np.nan for k in (
+            "accum_score", "rs_3m", "rs_accel", "breadth", "from_52w_high", "run_12m",
+        )}) == STAGE_DORMANT
+
+
+class TestBuildThemeSignals:
+    @pytest.fixture
+    def signals(self):
+        bench = _benchmark(0.0002)
+        themes = {
+            "leader": _frames(0.0020, volume_multiplier=2.5, close_position=0.9),
+            "laggard": _frames(-0.0015, close_position=0.1),
+            "flat": _frames(0.0002),
+        }
+        return build_theme_signals(themes, bench)
+
+    def test_returns_a_row_per_theme(self, signals):
+        assert set(signals.index) == {"leader", "laggard", "flat"}
+
+    def test_sorted_by_score_descending(self, signals):
+        assert signals["smart_money_score"].is_monotonic_decreasing
+
+    def test_accumulating_theme_outscores_distributing_one(self, signals):
+        assert signals.loc["leader", "accum_score"] > signals.loc["laggard", "accum_score"]
+
+    def test_every_theme_receives_a_stage(self, signals):
+        assert signals["stage"].notna().all()
+
+    def test_scores_stay_on_the_zero_to_hundred_scale(self, signals):
+        assert signals["smart_money_score"].between(0, 100).all()
+        assert signals["accum_score"].between(0, 100).all()
+
+    def test_series_are_attached_for_charting(self, signals):
+        assert set(signals.attrs["series"]) == {"leader", "laggard", "flat"}
+        assert not signals.attrs["series"]["leader"]["theme_index"].empty
+
+    def test_short_history_theme_is_flagged_unrankable(self):
+        bench = _benchmark(0.0002)
+        signals = build_theme_signals(
+            {"ok": _frames(0.001), "new_listing": _frames(0.001, n=40)}, bench,
+        )
+        assert bool(signals.loc["ok", "rankable"])
+        assert not bool(signals.loc["new_listing", "rankable"])
+
+    def test_short_history_theme_does_not_crash_or_rank(self):
+        bench = _benchmark(0.0002)
+        signals = build_theme_signals({"new_listing": _frames(0.001, n=40)}, bench)
+        assert signals.loc["new_listing", "stage"] == STAGE_DORMANT
+
+    def test_theme_with_too_few_constituents_is_unrankable(self):
+        bench = _benchmark(0.0002)
+        signals = build_theme_signals(
+            {"thin": _frames(0.001, tickers=("AAA",))}, bench, min_constituents=3,
+        )
+        assert not bool(signals.loc["thin", "rankable"])
+
+    def test_empty_benchmark_returns_empty(self):
+        assert build_theme_signals({"x": _frames(0.001)}, pd.Series(dtype=float)).empty
+
+    def test_no_themes_returns_empty(self):
+        assert build_theme_signals({}, _benchmark(0.0)).empty
+
+
+class TestTruncateFrames:
+    def test_drops_the_requested_number_of_bars(self):
+        truncated = truncate_frames({"t": _frames(0.001)}, 30)
+        assert len(truncated["t"]["Close"]) == BARS - 30
+
+    def test_zero_bars_is_a_no_op(self):
+        frames = {"t": _frames(0.001)}
+        assert len(truncate_frames(frames, 0)["t"]["Close"]) == BARS
+
+    def test_frames_shorter_than_the_cut_are_dropped(self):
+        truncated = truncate_frames({"t": _frames(0.001, n=10)}, 30)
+        assert truncated["t"] == {}
+
+    def test_as_of_recomputation_sees_no_future_data(self):
+        # A theme that only rallies in the final 30 bars must not look strong
+        # in the truncated snapshot.
+        close = _frames(0.0)["Close"]
+        close.iloc[-30:] *= 2.0
+        frames = {"late_mover": {**_frames(0.0), "Close": close}}
+        bench = _benchmark(0.0)
+        now = build_theme_signals(frames, bench)
+        before = build_theme_signals(truncate_frames(frames, 30), bench.iloc[:-30])
+        assert now.loc["late_mover", "rs_3m"] > before.loc["late_mover", "rs_3m"]
+
+
+class TestDiffStages:
+    def _snapshot(self, stages):
+        return pd.DataFrame({"stage": stages})
+
+    def test_move_into_accumulation_is_entering(self):
+        diff = diff_stages(
+            self._snapshot({"a": STAGE_ACCUMULATION}),
+            self._snapshot({"a": STAGE_DORMANT}),
+        )
+        assert diff.loc["a", "direction"] == "entering"
+
+    def test_early_stage_confirmed_by_price_is_maturing(self):
+        # A flagged theme graduating into momentum is the thesis paying off,
+        # and must not disappear into an unlabelled bucket.
+        diff = diff_stages(
+            self._snapshot({"a": STAGE_MOMENTUM}),
+            self._snapshot({"a": STAGE_ACCUMULATION}),
+        )
+        assert diff.loc["a", "direction"] == "maturing"
+
+    def test_every_transition_from_an_early_stage_is_labelled(self):
+        for after in (STAGE_MOMENTUM, STAGE_CROWDED, STAGE_DORMANT):
+            diff = diff_stages(
+                self._snapshot({"a": after}), self._snapshot({"a": STAGE_EARLY}),
+            )
+            assert diff.loc["a", "direction"] in {"maturing", "cooling", "entering"}
+
+    def test_rollover_into_crowded_is_cooling(self):
+        diff = diff_stages(
+            self._snapshot({"a": STAGE_CROWDED}),
+            self._snapshot({"a": STAGE_MOMENTUM}),
+        )
+        assert diff.loc["a", "direction"] == "cooling"
+
+    def test_unchanged_themes_are_omitted(self):
+        diff = diff_stages(
+            self._snapshot({"a": STAGE_MOMENTUM}),
+            self._snapshot({"a": STAGE_MOMENTUM}),
+        )
+        assert diff.empty
+
+    def test_themes_missing_from_one_side_are_skipped(self):
+        diff = diff_stages(
+            self._snapshot({"a": STAGE_EARLY, "b": STAGE_EARLY}),
+            self._snapshot({"a": STAGE_DORMANT}),
+        )
+        assert list(diff.index) == ["a"]
+
+    def test_empty_inputs_return_empty_frame(self):
+        assert diff_stages(pd.DataFrame(), pd.DataFrame()).empty
+
+
+class TestRotationMatrix:
+    def test_one_row_per_theme(self):
+        matrix = rotation_matrix(
+            {
+                "up": equal_weight_index(_frames(0.002)["Close"]),
+                "down": equal_weight_index(_frames(-0.002)["Close"]),
+            },
+            _benchmark(0.0),
+        )
+        assert set(matrix.index) == {"up", "down"}
+
+    def test_outperformer_scores_above_underperformer(self):
+        matrix = rotation_matrix(
+            {
+                "up": equal_weight_index(_frames(0.002)["Close"]),
+                "down": equal_weight_index(_frames(-0.002)["Close"]),
+            },
+            _benchmark(0.0),
+        )
+        assert matrix.loc["up"].mean() > matrix.loc["down"].mean()
+
+    def test_empty_benchmark_returns_empty(self):
+        assert rotation_matrix({"a": pd.Series([1.0])}, pd.Series(dtype=float)).empty
+
+
+class TestConstituentTable:
+    def test_lists_every_constituent(self):
+        table = constituent_table(_frames(0.001), _benchmark(0.0))
+        assert list(table.index) == ["AAA", "BBB", "CCC"]
+
+    def test_carries_the_expected_columns(self):
+        table = constituent_table(_frames(0.001), _benchmark(0.0))
+        for column in ["Last", "RS vs Benchmark (%)", "Money Flow (CMF)", "From 52w High (%)"]:
+            assert column in table.columns
+
+    def test_empty_frames_return_empty(self):
+        assert constituent_table({"Close": pd.DataFrame()}, _benchmark(0.0)).empty

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -1,0 +1,92 @@
+import re
+
+from common.themes import (
+    MIN_CONSTITUENTS,
+    THEMES,
+    all_tickers,
+    asset_classes,
+    theme_label,
+    themes_by_asset_class,
+)
+
+REQUIRED_KEYS = {"label", "icon", "asset_class", "thesis", "tickers"}
+TICKER_PATTERN = re.compile(r"^[A-Z0-9][A-Z0-9.\-=^]*$")
+
+
+class TestThemeDefinitions:
+    def test_every_theme_has_the_required_fields(self):
+        for slug, theme in THEMES.items():
+            assert REQUIRED_KEYS <= set(theme), f"{slug} is missing fields"
+
+    def test_every_theme_has_enough_constituents_to_score(self):
+        # Breadth and cross-sectional money flow are meaningless on a basket
+        # too small to disagree with itself.
+        for slug, theme in THEMES.items():
+            assert len(theme["tickers"]) >= MIN_CONSTITUENTS, slug
+
+    def test_tickers_are_yahoo_shaped(self):
+        for slug, theme in THEMES.items():
+            for ticker in theme["tickers"]:
+                assert TICKER_PATTERN.match(ticker), f"{slug}: {ticker}"
+
+    def test_no_duplicate_tickers_within_a_theme(self):
+        for slug, theme in THEMES.items():
+            assert len(theme["tickers"]) == len(set(theme["tickers"])), slug
+
+    def test_labels_and_theses_are_populated(self):
+        for slug, theme in THEMES.items():
+            assert theme["label"].strip(), slug
+            assert theme["thesis"].strip(), slug
+
+    def test_slugs_are_lowercase_identifiers(self):
+        for slug in THEMES:
+            assert re.match(r"^[a-z0-9_]+$", slug), slug
+
+
+class TestAllTickers:
+    def test_deduplicates_across_themes(self):
+        tickers = all_tickers()
+        assert len(tickers) == len(set(tickers))
+
+    def test_covers_every_theme_constituent(self):
+        tickers = set(all_tickers())
+        for theme in THEMES.values():
+            assert set(theme["tickers"]) <= tickers
+
+    def test_universe_stays_small_enough_for_one_batched_download(self):
+        # The page depends on fetching the whole universe in a single call.
+        assert len(all_tickers()) <= 150
+
+
+class TestAssetClassFilters:
+    def test_asset_classes_are_sorted_and_unique(self):
+        classes = asset_classes()
+        assert classes == sorted(set(classes))
+
+    def test_filtering_returns_only_that_class(self):
+        for asset_class in asset_classes():
+            subset = themes_by_asset_class(asset_class)
+            assert subset
+            assert all(t["asset_class"] == asset_class for t in subset.values())
+
+    def test_none_and_all_return_everything(self):
+        assert len(themes_by_asset_class(None)) == len(THEMES)
+        assert len(themes_by_asset_class("All")) == len(THEMES)
+
+    def test_unknown_class_returns_nothing(self):
+        assert themes_by_asset_class("Real Estate") == {}
+
+    def test_filtering_does_not_mutate_the_registry(self):
+        themes_by_asset_class(None).clear()
+        assert THEMES
+
+
+class TestThemeLabel:
+    def test_includes_icon_and_label(self):
+        for slug, theme in THEMES.items():
+            label = theme_label(slug)
+            assert theme["icon"] in label
+            assert theme["label"] in label
+
+    def test_unknown_slug_falls_back_to_the_slug(self):
+        assert theme_label("does_not_exist") == "does_not_exist"

--- a/views/smart_money.py
+++ b/views/smart_money.py
@@ -1,0 +1,510 @@
+from datetime import date, timedelta
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from common.data import get_benchmark_data, get_ohlcv_data
+from common.sec_edgar import (
+    CURATED_MANAGERS,
+    build_issuer_ticker_map,
+    diff_positions,
+    get_insider_buys,
+    get_manager_positions,
+    get_ticker_cik_map,
+    map_positions_to_tickers,
+)
+from common.smart_money import (
+    EARLY_STAGES,
+    STAGE_ACCUMULATION,
+    STAGE_CROWDED,
+    STAGE_EARLY,
+    build_theme_signals,
+    constituent_table,
+    diff_stages,
+    rotation_matrix,
+    truncate_frames,
+)
+from common.themes import THEMES, all_tickers, asset_classes, theme_label
+
+AS_OF_BARS = 30
+STAGE_COLORS = {
+    "🌱 Accumulation": "#2E8B57",
+    "🚀 Early Trend": "#1F77B4",
+    "🔥 Momentum": "#FF7F0E",
+    "⚠️ Crowded / Extended": "#D62728",
+    "💤 Dormant": "#9E9E9E",
+}
+
+st.title("🧭 Smart Money Radar")
+st.caption(
+    "Ranks thematic baskets by evidence of **accumulation** rather than by trailing return, "
+    "so a narrative can surface while it is still based. Price and volume signals are a "
+    "*proxy* for institutional flow, not actual flow data. The SEC panels below are real "
+    "filings: Form 4 insider purchases are timely, 13F holdings are filed up to 45 days "
+    "after quarter end and therefore confirm a theme rather than front-run it."
+)
+
+# --- Controls ---
+col_bench, col_class, col_hist = st.columns([2, 2, 2])
+BENCHMARKS = {"S&P 500": "^GSPC", "NASDAQ": "^IXIC", "Russell 2000": "^RUT", "Dow Jones": "^DJI"}
+benchmark_name = col_bench.selectbox("Benchmark", list(BENCHMARKS), index=0)
+benchmark_symbol = BENCHMARKS[benchmark_name]
+selected_class = col_class.selectbox("Asset class", ["All", *asset_classes()], index=0)
+years = col_hist.slider(
+    "Years of history", 2, 5, 3,
+    help="Signals need a full year of bars for 52-week extension plus a 30-day "
+         "look-back for the change alerts.",
+)
+
+end_date = date.today()
+start_date = end_date - timedelta(days=int(years * 365.25))
+
+with st.spinner("Loading theme constituents…"):
+    ohlcv = get_ohlcv_data(all_tickers(), start_date.isoformat(), end_date.isoformat())
+    benchmark = get_benchmark_data(benchmark_symbol, start_date.isoformat(), end_date.isoformat())
+
+if not ohlcv or benchmark.empty:
+    st.warning(
+        "Market data is unavailable right now (Yahoo Finance may be rate limiting). "
+        "Please try again in a few minutes."
+    )
+    st.stop()
+
+available = set(ohlcv["Close"].columns)
+theme_frames, missing = {}, {}
+for slug, theme in THEMES.items():
+    if selected_class != "All" and theme["asset_class"] != selected_class:
+        continue
+    present = [t for t in theme["tickers"] if t in available]
+    if not present:
+        continue
+    theme_frames[slug] = {
+        field: frame.reindex(columns=present) for field, frame in ohlcv.items()
+    }
+    absent = [t for t in theme["tickers"] if t not in available]
+    if absent:
+        missing[slug] = absent
+
+if not theme_frames:
+    st.warning("No theme returned usable price data for this selection.")
+    st.stop()
+
+signals = build_theme_signals(theme_frames, benchmark)
+if signals.empty:
+    st.warning("Not enough overlapping history to score the themes.")
+    st.stop()
+
+series = signals.attrs.get("series", {})
+signals = signals.assign(theme=[theme_label(slug) for slug in signals.index])
+
+# As-of snapshot: the whole pipeline is recomputed on truncated data, so the
+# cross-sectional z-scores cannot see anything that had not happened yet.
+before = build_theme_signals(
+    truncate_frames(theme_frames, AS_OF_BARS), benchmark.iloc[:-AS_OF_BARS],
+)
+alerts = diff_stages(signals, before)
+
+ranked = signals[signals["rankable"].astype(bool)]
+
+# --- What changed ---
+st.subheader("What Changed in the Last 30 Days")
+PANELS = [
+    ("entering", "🟢 Newly entering accumulation",
+     "No theme crossed into accumulation or early trend this month."),
+    ("maturing", "🔵 Confirmed by price",
+     "No early-stage theme graduated into momentum this month."),
+    ("cooling", "🟠 Cooling or newly crowded",
+     "No theme rolled over from a trending stage this month."),
+]
+for column, (direction, heading, empty_message) in zip(st.columns(3), PANELS):
+    with column.container(border=True):
+        st.markdown(f"**{heading}**")
+        moves = alerts[alerts["direction"] == direction] if not alerts.empty else alerts
+        if moves.empty:
+            st.caption(empty_message)
+        else:
+            for slug, row in moves.iterrows():
+                st.markdown(
+                    f"- {theme_label(slug)} — {row['stage_before']} → **{row['stage_now']}**"
+                )
+
+def _leader(frame, column):
+    """Index label of the highest finite value, or None if the column is empty."""
+    values = frame[column].dropna()
+    return values.idxmax() if not values.empty else None
+
+
+def _name(slug):
+    """Theme label without its leading icon, for compact metric tiles."""
+    return theme_label(slug).split(" ", 1)[-1]
+
+
+# --- Headline metrics ---
+if not ranked.empty:
+    st.subheader("Where Capital Is Moving")
+    early = ranked[ranked["stage"].isin(EARLY_STAGES)]
+    tiles = st.columns(4)
+
+    top_accum = _leader(ranked, "accum_score")
+    if top_accum is None:
+        tiles[0].metric("Strongest accumulation", "—")
+    else:
+        tiles[0].metric(
+            "Strongest accumulation", _name(top_accum),
+            f"{ranked.loc[top_accum, 'accum_score']:.0f}/100 flow score",
+        )
+
+    top_accel = _leader(ranked, "rs_accel")
+    if top_accel is None:
+        tiles[1].metric("Fastest inflection", "—")
+    else:
+        tiles[1].metric(
+            "Fastest inflection", _name(top_accel),
+            f"{ranked.loc[top_accel, 'rs_accel'] * 10000:+.1f} bps/day vs {benchmark_name}",
+        )
+
+    crowded = ranked[ranked["stage"] == STAGE_CROWDED]
+    worst = _leader(crowded, "run_12m") if not crowded.empty else None
+    if worst is None:
+        tiles[2].metric("Most crowded", "None flagged", "no theme extended and narrowing")
+    else:
+        tiles[2].metric(
+            "Most crowded", _name(worst),
+            f"{crowded.loc[worst, 'run_12m'] * 100:+.0f}% over 12m", delta_color="inverse",
+        )
+    tiles[3].metric(
+        "Themes still early", f"{len(early)} of {len(ranked)}",
+        "accumulation or early trend",
+    )
+
+# --- Leaderboard ---
+st.subheader("Theme Leaderboard")
+st.write(
+    "Ranked by a composite that weights money flow, dollar-volume expansion and broadening "
+    "participation far above trailing return — ranking on return alone would only ever "
+    "surface what has already worked."
+)
+
+DISPLAY_COLUMNS = {
+    "theme": "Theme",
+    "stage": "Stage",
+    "smart_money_score": "Score",
+    "accum_score": "Accumulation",
+    "cmf": "Money Flow",
+    "dv_thrust": "Vol Thrust (%)",
+    "rs_accel": "RS Accel (bps/d)",
+    "rs_3m": "RS 3M (%)",
+    "rs_6m": "RS 6M (%)",
+    "breadth": "Breadth (%)",
+    "from_52w_high": "From 52w High (%)",
+    "run_12m": "12M Run (%)",
+    "constituents": "Names",
+}
+board = signals.reindex(columns=list(DISPLAY_COLUMNS)).rename(columns=DISPLAY_COLUMNS)
+# The chart series ride along in .attrs; Streamlit cannot serialize them and
+# they are not needed for the table.
+board.attrs = {}
+for column in ["Vol Thrust (%)", "RS 3M (%)", "RS 6M (%)", "Breadth (%)",
+               "From 52w High (%)", "12M Run (%)"]:
+    board[column] = board[column] * 100
+board["RS Accel (bps/d)"] = board["RS Accel (bps/d)"] * 10000
+
+st.dataframe(
+    board, use_container_width=True, hide_index=True,
+    column_config={
+        "Score": st.column_config.ProgressColumn(
+            "Score", min_value=0, max_value=100, format="%.0f",
+            help="Composite: money flow, volume expansion and broadening participation, "
+                 "weighted above trailing return.",
+        ),
+        "Accumulation": st.column_config.ProgressColumn(
+            "Accumulation", min_value=0, max_value=100, format="%.0f",
+            help="Flow evidence only — excludes trailing return entirely.",
+        ),
+        "Money Flow": st.column_config.NumberColumn(format="%+.3f"),
+        "Vol Thrust (%)": st.column_config.NumberColumn(format="%+.1f%%"),
+        "RS Accel (bps/d)": st.column_config.NumberColumn(format="%+.1f"),
+        "RS 3M (%)": st.column_config.NumberColumn(format="%+.1f%%"),
+        "RS 6M (%)": st.column_config.NumberColumn(format="%+.1f%%"),
+        "Breadth (%)": st.column_config.NumberColumn(format="%.0f%%"),
+        "From 52w High (%)": st.column_config.NumberColumn(format="%.1f%%"),
+        "12M Run (%)": st.column_config.NumberColumn(format="%+.1f%%"),
+        "Names": st.column_config.NumberColumn(format="%d"),
+    },
+)
+st.download_button(
+    "Download signals as CSV", board.to_csv(index=False).encode("utf-8"),
+    file_name=f"smart_money_radar_{end_date.isoformat()}.csv", mime="text/csv",
+)
+
+unrankable = signals[~signals["rankable"].astype(bool)]
+if not unrankable.empty:
+    st.caption(
+        "Excluded from the cross-sectional scoring for insufficient history or too few "
+        "surviving constituents: "
+        + ", ".join(theme_label(slug) for slug in unrankable.index) + "."
+    )
+if missing:
+    st.caption(
+        "Symbols with no data returned: "
+        + "; ".join(f"{theme_label(s)} ({', '.join(t)})" for s, t in missing.items()) + "."
+    )
+
+# --- Quadrant ---
+if not ranked.empty:
+    st.subheader("Early vs Already-Run")
+    st.write(
+        "The horizontal axis is how much a theme has **already** outperformed over six "
+        "months; the vertical axis is how hard money is going in **now**. The top-left "
+        "quadrant — heavy accumulation, price still flat — is what this page exists to find."
+    )
+    quadrant = ranked.assign(
+        rs_6m_pct=ranked["rs_6m"] * 100,
+        thrust_size=ranked["dv_thrust"].abs().fillna(0) * 100 + 10,
+    )
+    fig = px.scatter(
+        quadrant, x="rs_6m_pct", y="accum_score", color="stage", text="theme",
+        size="thrust_size", size_max=38, color_discrete_map=STAGE_COLORS,
+        labels={"rs_6m_pct": f"6-month relative strength vs {benchmark_name} (%)",
+                "accum_score": "Accumulation score (flow going in now)",
+                "stage": "Lifecycle stage"},
+        hover_data={"thrust_size": False, "theme": False},
+    )
+    fig.update_traces(textposition="top center", textfont_size=10)
+    fig.add_hline(y=60, line_dash="dot", line_color="gray")
+    fig.add_vline(x=0, line_dash="dot", line_color="gray")
+    x_min, x_max = quadrant["rs_6m_pct"].min(), quadrant["rs_6m_pct"].max()
+    span = max(abs(x_min), abs(x_max), 5) * 0.75
+    for x_pos, y_pos, label in [
+        (-span, 92, "Under the radar — accumulating, hasn't run"),
+        (span, 92, "Confirmed leaders — flow and price both in"),
+        (-span, 12, "Falling knives — no flow, no trend"),
+        (span, 12, "Distribution risk — price ran, flow fading"),
+    ]:
+        fig.add_annotation(x=x_pos, y=y_pos, text=label, showarrow=False,
+                           font=dict(size=10, color="gray"))
+    fig.update_layout(height=560)
+    st.plotly_chart(fig, use_container_width=True)
+
+# --- Rotation ---
+st.subheader("Theme Rotation Over Time")
+st.write(
+    "Monthly relative strength versus the benchmark. Reading across a row shows a narrative "
+    "gaining and losing sponsorship; reading down a column shows what capital rotated into "
+    "that month."
+)
+rotation = rotation_matrix(
+    {slug: payload["theme_index"] for slug, payload in series.items()}, benchmark,
+)
+if rotation.empty:
+    st.info("Not enough history to build the rotation heatmap.")
+else:
+    rotation = rotation.iloc[:, -18:]
+    rotation.index = [theme_label(slug) for slug in rotation.index]
+    rotation.columns = [pd.Timestamp(c).strftime("%b %Y") for c in rotation.columns]
+    heat = px.imshow(
+        rotation, text_auto=".0f", aspect="auto", color_continuous_scale="RdYlGn",
+        color_continuous_midpoint=0,
+        labels={"color": "Relative strength (%)", "x": "Month", "y": ""},
+    )
+    heat.update_layout(height=max(360, 26 * len(rotation)))
+    st.plotly_chart(heat, use_container_width=True)
+
+# --- Drill-down ---
+st.subheader("Theme Detail")
+choice = st.selectbox(
+    "Theme", list(signals.index), format_func=theme_label,
+    index=0,
+)
+detail = signals.loc[choice]
+theme_meta = THEMES[choice]
+st.markdown(f"**{theme_meta['thesis']}**")
+
+info = st.columns(4)
+info[0].metric("Stage", detail["stage"])
+info[1].metric("Smart money score", f"{detail['smart_money_score']:.0f}/100"
+               if np.isfinite(detail["smart_money_score"]) else "—")
+info[2].metric("Money flow (CMF)", f"{detail['cmf']:+.3f}"
+               if np.isfinite(detail["cmf"]) else "—")
+info[3].metric("Dollar-volume thrust", f"{detail['dv_thrust'] * 100:+.0f}%"
+               if np.isfinite(detail["dv_thrust"]) else "—")
+
+trend_tab, names_tab, insider_tab = st.tabs(
+    ["Trend & breadth", "Constituents", "Insider buying (SEC Form 4)"]
+)
+
+with trend_tab:
+    payload = series.get(choice, {})
+    theme_index = payload.get("theme_index", pd.Series(dtype=float))
+    if theme_index.empty:
+        st.info("No index series available for this theme.")
+    else:
+        bench_norm = benchmark.reindex(theme_index.index).ffill()
+        bench_norm = bench_norm / bench_norm.dropna().iloc[0] * 100
+        growth = pd.DataFrame({
+            theme_meta["label"]: theme_index / theme_index.iloc[0] * 100,
+            benchmark_name: bench_norm,
+        }).dropna(how="all")
+        st.plotly_chart(
+            px.line(growth, labels={"value": "Growth of 100", "index": "Date",
+                                    "variable": ""},
+                    title=f"{theme_meta['label']} vs {benchmark_name}"),
+            use_container_width=True,
+        )
+        breadth = payload.get("breadth_series", pd.Series(dtype=float)).dropna() * 100
+        if not breadth.empty:
+            st.plotly_chart(
+                px.area(breadth, labels={"value": "% above 50-day average", "index": "Date"},
+                        title="Participation: share of constituents in an uptrend")
+                .update_layout(showlegend=False, yaxis_range=[0, 100]),
+                use_container_width=True,
+            )
+            st.caption(
+                "Breadth rising alongside price means the move is broadening. Price making "
+                "new highs while breadth falls means fewer names are carrying it."
+            )
+
+with names_tab:
+    table = constituent_table(theme_frames[choice], benchmark)
+    if table.empty:
+        st.info("No constituent data available.")
+    else:
+        st.dataframe(
+            table, use_container_width=True,
+            column_config={
+                "Last": st.column_config.NumberColumn(format="%.2f"),
+                "Return 3M (%)": st.column_config.NumberColumn(format="%+.1f%%"),
+                "RS vs Benchmark (%)": st.column_config.NumberColumn(format="%+.1f%%"),
+                "Dollar Vol Thrust (%)": st.column_config.NumberColumn(format="%+.1f%%"),
+                "Money Flow (CMF)": st.column_config.NumberColumn(format="%+.3f"),
+                "From 52w High (%)": st.column_config.NumberColumn(format="%.1f%%"),
+            },
+        )
+
+with insider_tab:
+    st.write(
+        "Open-market purchases (Form 4 transaction code **P**) by officers and directors of "
+        "this theme's constituents. Grants, option exercises and tax-withholding sales are "
+        "excluded — they are scheduled compensation events, not conviction. Genuine "
+        "open-market buys are rare, so an empty result is a normal outcome."
+    )
+    lookback_days = st.select_slider(
+        "Look back", options=[30, 90, 180, 365], value=180, key="insider_days",
+    )
+    if st.button("Load insider filings from SEC EDGAR", key="load_insiders"):
+        with st.spinner("Fetching Form 4 filings…"):
+            try:
+                buys = get_insider_buys(tuple(theme_meta["tickers"]), days=lookback_days)
+            except Exception as e:  # EDGAR outage must not break the page
+                st.error(f"Could not reach SEC EDGAR: {e}")
+                buys = pd.DataFrame()
+        if buys.empty:
+            st.info(
+                f"No open-market insider purchases filed for these names in the last "
+                f"{lookback_days} days."
+            )
+        else:
+            st.metric("Total insider buying", f"${buys['value'].sum():,.0f}")
+            st.dataframe(
+                buys.style.format({
+                    "shares": "{:,.0f}", "price": "{:,.2f}", "value": "${:,.0f}",
+                    "transaction_date": lambda d: pd.Timestamp(d).strftime("%Y-%m-%d"),
+                }, na_rep="—"),
+                use_container_width=True, hide_index=True,
+            )
+
+# --- 13F ---
+st.subheader("Institutional Positioning (SEC 13F)")
+with st.expander("Quarter-over-quarter changes across well-known managers"):
+    st.write(
+        "Position changes between the two most recent 13F filings of "
+        f"{len(CURATED_MANAGERS)} managers, aggregated onto the themes above. "
+        "**13F filings are due 45 days after quarter end**, so this confirms which "
+        "narratives institutions were building into — it does not front-run them. "
+        "Only long US equity positions are reportable; shorts, cash and non-US "
+        "holdings are invisible here."
+    )
+    if st.button("Load 13F filings from SEC EDGAR", key="load_13f"):
+        ticker_to_theme = {
+            ticker: slug for slug, theme in THEMES.items() for ticker in theme["tickers"]
+        }
+        progress = st.progress(0.0, text="Fetching 13F filings…")
+        rows, quarters = [], set()
+        try:
+            cik_map = get_ticker_cik_map()
+            issuer_map = build_issuer_ticker_map({
+                ticker: cik_map[ticker]["title"]
+                for ticker in ticker_to_theme if ticker in cik_map
+            })
+            for i, (cik, name) in enumerate(CURATED_MANAGERS.items(), start=1):
+                progress.progress(i / len(CURATED_MANAGERS), text=f"Fetching {name}…")
+                current, prior, current_date, prior_date = get_manager_positions(cik)
+                if current.empty:
+                    continue
+                quarters.add((str(prior_date), str(current_date)))
+                changes = diff_positions(
+                    map_positions_to_tickers(current, issuer_map),
+                    map_positions_to_tickers(prior, issuer_map),
+                )
+                changes = changes.dropna(subset=["ticker"])
+                if changes.empty:
+                    continue
+                changes["manager"] = name
+                changes["theme"] = changes["ticker"].map(ticker_to_theme)
+                rows.append(changes)
+        except Exception as e:
+            st.error(f"Could not reach SEC EDGAR: {e}")
+            rows = []
+        finally:
+            progress.empty()
+
+        if not rows:
+            st.info("No mapped 13F positions were returned. Try again shortly.")
+        else:
+            holdings = pd.concat(rows, ignore_index=True).dropna(subset=["theme"])
+            if quarters:
+                prior_q, current_q = sorted(quarters)[-1]
+                st.caption(f"Comparing quarter ending {prior_q} → {current_q}.")
+
+            by_theme = (
+                holdings.groupby("theme")
+                .agg(**{
+                    "Net $ change": ("value_change", "sum"),
+                    "Position value": ("value", "sum"),
+                    "New stakes": ("action", lambda a: (a == "New").sum()),
+                    "Adds": ("action", lambda a: (a == "Added").sum()),
+                    "Trims": ("action", lambda a: (a == "Trimmed").sum()),
+                })
+                .sort_values("Net $ change", ascending=False)
+            )
+            by_theme.index = [theme_label(slug) for slug in by_theme.index]
+            st.plotly_chart(
+                px.bar(by_theme.reset_index(), x="Net $ change", y="index",
+                       orientation="h", color="Net $ change",
+                       color_continuous_scale="RdYlGn", color_continuous_midpoint=0,
+                       labels={"index": "", "Net $ change": "Net change in reported value ($)"},
+                       title="Net institutional buying by theme, last quarter")
+                .update_layout(height=max(320, 30 * len(by_theme)), showlegend=False),
+                use_container_width=True,
+            )
+            st.dataframe(
+                by_theme.style.format({
+                    "Net $ change": "${:,.0f}", "Position value": "${:,.0f}",
+                    "New stakes": "{:.0f}", "Adds": "{:.0f}", "Trims": "{:.0f}",
+                }),
+                use_container_width=True,
+            )
+
+            st.markdown("**Largest single position changes**")
+            movers = holdings.reindex(
+                columns=["manager", "ticker", "issuer", "action", "value", "value_change"]
+            ).sort_values("value_change", key=abs, ascending=False).head(25)
+            movers["theme"] = movers["ticker"].map(
+                lambda t: theme_label(ticker_to_theme.get(t, ""))
+            )
+            st.dataframe(
+                movers.style.format({"value": "${:,.0f}", "value_change": "${:+,.0f}"}),
+                use_container_width=True, hide_index=True,
+            )


### PR DESCRIPTION
Every existing page analyses a portfolio the user already holds. Nothing
answered "which narrative is capital rotating into, before it's obvious?"

Adds a page that scans 16 thematic baskets (AI compute, AI software, crypto
equities and spot, nuclear, power/grid, quantum, space, cybersecurity,
robotics, GLP-1, rare earths, clean energy, eVTOL, precious metals, semicap)
and ranks them by accumulation evidence rather than trailing return.

Two evidence layers, both free and key-less:

1. Price/volume accumulation proxy (Yahoo Finance) — Chaikin Money Flow,
   dollar-volume thrust, relative-strength acceleration and breadth. Trailing
   return carries only 10% of the composite weight, because ranking on return
   alone only ever surfaces what has already worked. On live data this puts AI
   & Accelerated Compute at 21/100 despite a +142% 12-month run, since its
   money flow, volume thrust and acceleration have all rolled over.

2. SEC EDGAR filings — Form 4 open-market insider purchases and 13F
   institutional position changes. Only transaction code P counts as a buy;
   codes A/M/F are compensation mechanics and outnumber real purchases roughly
   70:1 in practice.

A lifecycle classifier separates Accumulation / Early Trend / Momentum /
Crowded-Extended, checking extension first so an already-tripled theme cannot
be relabelled as momentum once breadth narrows. A 30-day alert panel diffs
stages against a snapshot recomputed on truncated data, so the cross-sectional
z-scores cannot see anything that had not yet happened.

Details:
- common/themes.py, common/smart_money.py: pure, no Streamlit, unit tested
  against synthetic frames (matches common/dates.py and common/options.py).
- common/sec_edgar.py: parsers pure and fixture-tested; network wrappers
  throttled to 8 req/s with backoff, since EDGAR answers a burst with 403.
  Contact address for the required User-Agent comes from SEC_CONTACT_EMAIL.
- common/data.py: adds get_ohlcv_data for volume and intraday range; existing
  get_price_data signature and behaviour unchanged.
- Themes are put on the benchmark's trading calendar before scoring, so crypto
  weekend bars do not make its 21-bar windows shorter than the equities'.
- No new dependencies. Uses st.column_config rather than Styler gradients,
  which would have pulled in matplotlib and broken the deploy.

105 new tests; suite goes 50 -> 155.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0195nenXL8HRTwFRbuvsZne8